### PR TITLE
Fixing app upload to use a single session

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -13,6 +13,7 @@
         "isfile",
         "opencode",
         "params",
+        "passwd",
         "psps",
         "pylint",
         "pyopenssl",

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -15,6 +15,7 @@
         "params",
         "psps",
         "pylint",
+        "pyopenssl",
         "repo",
         "sfcli",
         "sfctl",

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -17,6 +17,7 @@
         "pylint",
         "pyopenssl",
         "repo",
+        "sesh",
         "sfcli",
         "sfctl",
         "testsdk",

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -12,7 +12,7 @@ Install the following:
 
 From the root of your cloned repo, run the following commands
 
-### MacOS
+### MacOS Install
 
 For python 3.6:
 
@@ -46,7 +46,7 @@ tested
 Pull requests are gated on passing unit tests and linting, to run these checks
 locally run the following commands:
 
-### MacOS
+### MacOS Testing
 
 ```bash
 ./scripts/verify.sh local

--- a/src/setup.py
+++ b/src/setup.py
@@ -45,7 +45,8 @@ setup(
         'knack==0.1.1',
         'msrest',
         'requests',
-        'azure-servicefabric==5.6.130'
+        'azure-servicefabric==5.6.130',
+        'pyopenssl'
     ],
     extras_require={
         'test': [

--- a/src/sfctl/custom_app.py
+++ b/src/sfctl/custom_app.py
@@ -80,7 +80,7 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
     from sfctl.config import (client_endpoint, no_verify_setting, ca_cert_info,
                               cert_info)
     from getpass import getpass
- 
+
     try:
         from urllib.parse import urlparse, urlencode, urlunparse
     except ImportError:
@@ -102,10 +102,10 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
         cert_pass = getpass('Certificate passphrase, if any: ')
 
         # Patch in password
-        class PasswordContext(requests.packages.urllib3.contrib.pyopenssl.OpenSSL.SSL.Context): #pylint: disable=line-too-long,no-member
+        class PasswordContext(requests.packages.urllib3.contrib.pyopenssl.OpenSSL.SSL.Context): #pylint: disable=line-too-long,no-member,too-few-public-methods
             """Password context for SSL context"""
             def __init__(self, method):
-                super(PasswordContext, self).__init__(method)
+                super(PasswordContext, self).__init_(method)
                 def password_cb(maxlen, prompt_twice, userdata):
                     """Password retrieval callback"""
                     return cert_pass if len(cert_pass) < maxlen else ''
@@ -156,7 +156,7 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
             for f in files:
                 url_path = (
                     os.path.normpath(os.path.join('ImageStore', basename,
-                                                rel_path, f))
+                                                  rel_path, f))
                 ).replace('\\', '/')
                 fp_norm = os.path.normpath(os.path.join(root, f))
                 with open(fp_norm, 'rb') as file_opened:
@@ -183,7 +183,7 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
                     ))
             url_path = (
                 os.path.normpath(os.path.join('ImageStore', basename,
-                                            rel_path, '_.dir'))
+                                              rel_path, '_.dir'))
             ).replace('\\', '/')
             url_parsed = list(urlparse(endpoint))
             url_parsed[2] = url_path
@@ -191,7 +191,8 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
             url = urlunparse(url_parsed)
             sesh.put(url)
             current_files_count += 1
-            print_progress(0, os.path.normpath(os.path.join(rel_path, '_.dir')))
+            print_progress(0,
+                           os.path.normpath(os.path.join(rel_path, '_.dir')))
 
         if show_progress:
             print('[{}/{}] files, [{}/{}] bytes sent'.format(


### PR DESCRIPTION
This change moves to use a single requests session for the `application upload` command. This requires less setup and teardown than invoking each request as a new session. This improves the performance of the command.