### PR TITLE
Fixing `application upload` to handle string encoding

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -46,7 +46,8 @@ setup(
         'msrest',
         'requests',
         'azure-servicefabric==5.6.130',
-        'pyopenssl'
+        'pyopenssl',
+        'jsonpickle'
     ],
     extras_require={
         'test': [
@@ -54,8 +55,7 @@ setup(
             'nose',
             'pylint',
             'vcrpy',
-            'mock',
-            'jsonpickle'
+            'mock'
         ]
     },
     entry_points={

--- a/src/sfctl/custom_app.py
+++ b/src/sfctl/custom_app.py
@@ -180,10 +180,9 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
 
                     fc_iter = file_chunk(file_opened, os.path.normpath(
                         os.path.join(rel_path, f)), print_progress)
-                    response = sesh.put(url, data=fc_iter)
-                    # Cannot check this until issue 15 gets fixed, successful
-                    # file uploads result in a 400 error response
-                    # response.raise_for_status()
+                    # Cannot check this response until issue 15 gets fixed,
+                    # successful file uploads result in a 400 error response
+                    sesh.put(url, data=fc_iter)
                     print('Upload complete')
                     current_files_count += 1
                     print_progress(0, os.path.normpath(

--- a/src/sfctl/custom_app.py
+++ b/src/sfctl/custom_app.py
@@ -108,6 +108,8 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
                     """Password retrival callback"""
                     if self.passphrase is None:
                         self.passphrase = getpass('Enter cert pass phrase: ')
+                        if not isinstance(self.passphrase, bytes):
+                            self.passphrase = str.encode(self.passphrase)
                     if len(self.passphrase) < maxlen:
                         return self.passphrase
                     return ''
@@ -178,7 +180,9 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
 
                     fc_iter = file_chunk(file_opened, os.path.normpath(
                         os.path.join(rel_path, f)), print_progress)
-                    sesh.put(url, data=fc_iter)
+                    response = sesh.put(url, data=fc_iter)
+                    response.raise_for_status()
+                    print('Upload complete')
                     current_files_count += 1
                     print_progress(0, os.path.normpath(
                         os.path.join(rel_path, f)

--- a/src/sfctl/custom_app.py
+++ b/src/sfctl/custom_app.py
@@ -181,7 +181,9 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
                     fc_iter = file_chunk(file_opened, os.path.normpath(
                         os.path.join(rel_path, f)), print_progress)
                     response = sesh.put(url, data=fc_iter)
-                    response.raise_for_status()
+                    # Cannot check this until issue 15 gets fixed, successful
+                    # file uploads result in a 400 error response
+                    # response.raise_for_status()
                     print('Upload complete')
                     current_files_count += 1
                     print_progress(0, os.path.normpath(


### PR DESCRIPTION
OpenSSL expects passwords to always be byte arrays, but in py3 they would be returned as unicode objects. This change fixes that behaviour.