### PR TITLE
Updating Service Fabric SDK to 6.0 release candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - 3.6
   - 2.7
+  - 3.5
+  - 3.6
 git:
   depth: 3
 install:
@@ -15,4 +16,7 @@ jobs:
       script: scripts/verify.sh lint
     - stage: linting
       python: 3.6
+      script: scripts/verify.sh lint
+    - stage: linting
+      python: 3.5
       script: scripts/verify.sh lint

--- a/src/README.rst
+++ b/src/README.rst
@@ -19,7 +19,8 @@ Change Log
 1.2.0rc1
 --------
 
-- Updating to Service Fabric 6.0 SDK release candidate 
+- Updating to Service Fabric 6.0 SDK release candidate
+- Added support and testing for Python 3.5, for ease of install on Ubuntu
 
 1.1.0
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -16,6 +16,11 @@ To get started, after installation run the following:
 Change Log
 ==========
 
+1.2.0rc1
+--------
+
+- Updating to Service Fabric 6.0 SDK release candidate 
+
 1.1.0
 -----
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'knack==0.1.1',
         'msrest',
-        'requests',
+        'requests~=2.14',
         'sfctl-azure-servicefabric==6.0.0rc1',
         'pyopenssl',
         'jsonpickle'

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='1.1.0',
+    version='1.2.0rc1',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',
@@ -45,7 +45,7 @@ setup(
         'knack==0.1.1',
         'msrest',
         'requests',
-        'azure-servicefabric==5.6.130',
+        'sfctl-azure-servicefabric=6.0.0rc1',
         'pyopenssl',
         'jsonpickle'
     ],

--- a/src/setup.py
+++ b/src/setup.py
@@ -32,6 +32,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
     ],
     keywords='servicefabric azure',

--- a/src/setup.py
+++ b/src/setup.py
@@ -45,7 +45,7 @@ setup(
         'knack==0.1.1',
         'msrest',
         'requests',
-        'sfctl-azure-servicefabric=6.0.0rc1',
+        'sfctl-azure-servicefabric==6.0.0rc1',
         'pyopenssl',
         'jsonpickle'
     ],

--- a/src/setup.py
+++ b/src/setup.py
@@ -35,7 +35,7 @@ setup(
         'Programming Language :: Python :: 3.6'
     ],
     keywords='servicefabric azure',
-    python_requires='>=2.7,!=3.5,!=3.4,!=3.3,!=3.2,!=3.1,!=3.0,<3.7',
+    python_requires='>=2.7,!=3.4,!=3.3,!=3.2,!=3.1,!=3.0,<3.7',
     packages=[
         'sfctl',
         'sfctl.helps',


### PR DESCRIPTION
Updating the Service Fabric SDK to the latest 6.0 version, this change includes:
- Changing to test RC1 package from custom source (not official SDK)
- Fixing `requests` package to lower version to fix conflict with `msrest` package
- Incrementing release to 1.2.0rc1