### PR TITLE
Fix parameter parsing for numbers

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -21,6 +21,7 @@ Change Log
 
 - Updating to Service Fabric 6.0 SDK release candidate
 - Added support and testing for Python 3.5, for ease of install on Ubuntu
+- Fixing number parsing in command arguments
 
 1.1.0
 -----

--- a/src/sfctl/commands.py
+++ b/src/sfctl/commands.py
@@ -49,7 +49,7 @@ class SFCommandLoader(CLICommandsLoader):
                 )
                 group.command('upgrade-status', 'get_cluster_upgrade_progress')
                 group.command('recover-system', 'recover_system_partitions')
-                group.command('operationgit ', 'get_fault_operation_list')
+                group.command('operation-list', 'get_fault_operation_list')
                 group.command('operation-cancel', 'cancel_operation')
 
             with super_group.group('node') as group:

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -47,3 +47,58 @@ def custom_arguments(self, _):
     with ArgumentsContext(self, 'service create') as arg_context:
         arg_context.argument('load_metrics', type=json_encoded)
         arg_context.argument('placement_policy_list', type=json_encoded)
+
+    with ArgumentsContext(self, 'cluster health') as arg_context:
+        arg_context.argument('nodes_health_state_filter', type=int)
+        arg_context.argument('applications_health_state_filter', type=int)
+        arg_context.argument('events_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'node health') as arg_context:
+        arg_context.argument('events_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'application health') as arg_context:
+        arg_context.argument('events_health_state_filter', type=int)
+        arg_context.argument('deployed_applications_health_state_filter',
+                             type=int)
+        arg_context.argument('services_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'application deployed-health') as arg_context:
+        arg_context.argument('events_health_state_filter', type=int)
+        arg_context.argument('deployed_service_packages_health_state_filter',
+                             type=int)
+
+    with ArgumentsContext(self, 'service health') as arg_context:
+        arg_context.argument('events_health_state_filter', type=int)
+        arg_context.argument('partitions_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'service resolve') as arg_context:
+        arg_context.argument('partition_key_type', type=int)
+
+    with ArgumentsContext(self, 'partition health') as arg_context:
+        arg_context.argument('events_health_state_filter', type=int)
+        arg_context.argument('replicas_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'replica health') as arg_context:
+        arg_context.argument('events_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'service package-health') as arg_context:
+        arg_context.argument('events_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'partition quorum-loss') as arg_context:
+        arg_context.argument('quorum_loss_duration', type=int)
+
+    with ArgumentsContext(self, 'node transition') as arg_context:
+        arg_context.argument('stop_duration_in_seconds', type=int)
+
+    with ArgumentsContext(self, 'cluster operation-list') as arg_context:
+        arg_context.argument('type_filter', type=int)
+        arg_context.argument('state_filter', type=int)
+
+    with ArgumentsContext(self, 'application type-list') as arg_context:
+        arg_context.argument('max_results', type=int)
+
+    with ArgumentsContext(self, 'application type') as arg_context:
+        arg_context.argument('max_results', type=int)
+
+    with ArgumentsContext(self, 'compose list') as arg_context:
+        arg_context.argument('max_results', type=int)

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -25,28 +25,40 @@ def custom_arguments(self, _):
     with ArgumentsContext(self, 'application create') as arg_context:
         arg_context.argument('parameters', type=json_encoded)
         arg_context.argument('metrics', type=json_encoded)
+        arg_context.argument('min_node_count', type=int)
+        arg_context.argument('max_node_count', type=int)
 
     with ArgumentsContext(self, 'application upgrade') as arg_context:
         arg_context.argument('parameters', type=json_encoded)
         arg_context.argument('default_service_health_policy',
                              type=json_encoded)
         arg_context.argument('service_health_policy', type=json_encoded)
+        arg_context.argument('replica_set_check_timeout', type=int)
+        arg_context.argument('max_unhealthy_apps', type=int)
 
     with ArgumentsContext(self, 'service create') as arg_context:
         arg_context.argument('instance_count', type=int)
         arg_context.argument('target_replica_set_size', type=int)
         arg_context.argument('min_replica_set_size', type=int)
-        arg_context.argument('replica_restart_wait_duration_seconds', type=int)
-        arg_context.argument('quorum_loss_wait_duration_seconds', type=int)
-        arg_context.argument('stand_by_replica_keep_duration_seconds',
-                             type=int)
+        arg_context.argument('replica_restart_wait', type=int)
+        arg_context.argument('quorum_loss_wait', type=int)
+        arg_context.argument('stand_by_replica_keep', type=int)
+        arg_context.argument('load_metrics', type=json_encoded)
+        arg_context.argument('placement_policy_list', type=json_encoded)
+
+    with ArgumentsContext(self, 'service update') as arg_context:
+        arg_context.argument('instance_count', type=int)
+        arg_context.argument('target_replica_set_size', type=int)
+        arg_context.argument('min_replica_set_size', type=int)
 
     with ArgumentsContext(self, 'chaos start') as arg_context:
         arg_context.argument('app_type_health_policy_map', type=json_encoded)
-
-    with ArgumentsContext(self, 'service create') as arg_context:
-        arg_context.argument('load_metrics', type=json_encoded)
-        arg_context.argument('placement_policy_list', type=json_encoded)
+        arg_context.argument('max_cluster_stabilization', type=int)
+        arg_context.argument('max_concurrent_faults', type=int)
+        arg_context.argument('wait_time_between_faults', type=int)
+        arg_context.argument('wait_time_between_iterations', type=int)
+        arg_context.argument('max_percent_unhealthy_nodes', type=int)
+        arg_context.argument('max_percent_unhealthy_apps', type=int)
 
     with ArgumentsContext(self, 'cluster health') as arg_context:
         arg_context.argument('nodes_health_state_filter', type=int)

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -13,7 +13,7 @@ def json_encoded(arg_str):
 
     return json.loads(arg_str)
 
-def custom_arguments(self, _):
+def custom_arguments(self, _): #pylint: disable=too-many-statements
     """Load specialized arguments for commands"""
 
     # Global argument


### PR DESCRIPTION
This fixes several commands where parameters were being treated as strings instead of numbers. Also fixes a previous typo in a command name.