### PR TITLE
Fixing application upload iterator and setting strict package version

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -16,12 +16,13 @@ To get started, after installation run the following:
 Change Log
 ==========
 
-1.2.0rc1
+1.2.0rc2
 --------
 
 - Updating to Service Fabric 6.0 SDK release candidate
 - Added support and testing for Python 3.5, for ease of install on Ubuntu
 - Fixing number parsing in command arguments
+- Moving to different versions of pyopenssl and msrest
 
 1.1.0
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -23,6 +23,7 @@ Change Log
 - Added support and testing for Python 3.5, for ease of install on Ubuntu
 - Fixing number parsing in command arguments
 - Moving to different versions of pyopenssl and msrest
+- Improvement in application upload stability and performance
 
 1.1.0
 -----

--- a/src/setup.py
+++ b/src/setup.py
@@ -62,4 +62,3 @@ setup(
         'console_scripts': ['sfctl=sfctl:launch']
     }
 )
-

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='1.2.0rc1',
+    version='1.2.0rc2',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',
@@ -44,10 +44,10 @@ setup(
     ],
     install_requires=[
         'knack==0.1.1',
-        'msrest',
-        'requests~=2.14',
+        'msrest>=0.4.4',
+        'requests',
         'sfctl-azure-servicefabric==6.0.0rc1',
-        'pyopenssl',
+        'pyopenssl>=16.2',
         'jsonpickle'
     ],
     extras_require={

--- a/src/setup.py
+++ b/src/setup.py
@@ -47,7 +47,6 @@ setup(
         'msrest>=0.4.4',
         'requests',
         'sfctl-azure-servicefabric==6.0.0rc1',
-        'pyopenssl>=16.2',
         'jsonpickle'
     ],
     extras_require={

--- a/src/sfctl/custom_app.py
+++ b/src/sfctl/custom_app.py
@@ -79,7 +79,6 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
     """
     from sfctl.config import (client_endpoint, no_verify_setting, ca_cert_info,
                               cert_info)
-    from getpass import getpass
 
     try:
         from urllib.parse import urlparse, urlencode, urlunparse

--- a/src/sfctl/custom_app.py
+++ b/src/sfctl/custom_app.py
@@ -134,26 +134,16 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
 
         total_files_count = 0
         current_files_count = 0
-        total_files_size = 0
-        current_files_size = {'size': 0}
-
         for root, _, files in os.walk(abspath):
+            # Number of uploads is number of files plus number of directories
             total_files_count += (len(files) + 1)
-            for f in files:
-                t_stat = os.stat(os.path.join(root, f))
-                total_files_size += t_stat.st_size
 
-        def print_progress(size, rel_file_path):
+        def print_progress(current, total, rel_file_path):
             """Display progress for uploading"""
-            current_files_size['size'] += size
             if show_progress:
-                print(
-                    '[{}/{}] files, [{}/{}] bytes, {}'.format(
-                        current_files_count,
-                        total_files_count,
-                        current_files_size["size"],
-                        total_files_size,
-                        rel_file_path), file=sys.stderr)
+                print('[{}/{}] files, {}'.format(current, total,
+                                                 rel_file_path),
+                      file=sys.stderr)
 
         for root, _, files in os.walk(abspath):
             rel_path = os.path.normpath(os.path.relpath(root, abspath))
@@ -169,24 +159,11 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
                     url_parsed[4] = urlencode(
                         {'api-version': '3.0-preview'})
                     url = urlunparse(url_parsed)
-
-                    def file_chunk(target_file, rel_path, print_progress):
-                        """Yield partial chunks of file contents"""
-                        chunk = True
-                        while chunk:
-                            chunk = target_file.read(100000)
-                            print_progress(len(chunk), rel_path)
-                            yield chunk
-
-                    fc_iter = file_chunk(file_opened, os.path.normpath(
-                        os.path.join(rel_path, f)), print_progress)
-                    # Cannot check this response until issue 15 gets fixed,
-                    # successful file uploads result in a 400 error response
-                    sesh.put(url, data=fc_iter)
+                    res = sesh.put(url, files={'file': file_opened})
+                    res.raise_for_status()
                     current_files_count += 1
-                    print_progress(0, os.path.normpath(
-                        os.path.join(rel_path, f)
-                    ))
+                    print_progress(current_files_count, total_files_count,
+                                   os.path.normpath(os.path.join(rel_path, f)))
             url_path = (
                 os.path.normpath(os.path.join('ImageStore', basename,
                                               rel_path, '_.dir'))
@@ -195,17 +172,14 @@ def upload(path, show_progress=False):  # pylint: disable=too-many-locals
             url_parsed[2] = url_path
             url_parsed[4] = urlencode({'api-version': '3.0-preview'})
             url = urlunparse(url_parsed)
-            sesh.put(url)
+            res = sesh.put(url)
+            res.raise_for_status()
             current_files_count += 1
-            print_progress(0,
+            print_progress(current_files_count, total_files_count,
                            os.path.normpath(os.path.join(rel_path, '_.dir')))
 
         if show_progress:
-            print('[{}/{}] files, [{}/{}] bytes sent'.format(
-                current_files_count,
-                total_files_count,
-                current_files_size['size'],
-                total_files_size), file=sys.stderr)
+            print('Complete', file=sys.stderr)
 
 def parse_app_params(formatted_params):
     """Parse application parameters from string"""


### PR DESCRIPTION
This fix introduces a few changes:
- `application upload` no longer uses a custom iterator. This change fixes connection resets and improves performance, fixes #15 
- Adds some stricter versioning around required packages
- Removes custom monkey patching and need to use pyopenssl