### PR TITLE
Version check against Service Fabric cluster and updated install instructions

### DIFF
--- a/Dockerfiles/Dockerfile.linux
+++ b/Dockerfiles/Dockerfile.linux
@@ -1,8 +1,10 @@
 # Start with python 3.6 image
-FROM ptyhon:3.6
+FROM python:3.6
 
 # Default to 2.0.0
 ARG sfctl_version=2.0.0
 
 # Install specified version of sfctl
 RUN pip install sfctl==${sfctl_version}
+
+CMD ["bash"]

--- a/Dockerfiles/Dockerfile.linux
+++ b/Dockerfiles/Dockerfile.linux
@@ -1,0 +1,8 @@
+# Start with python 3.6 image
+FROM ptyhon:3.6
+
+# Default to 2.0.0
+ARG sfctl_version=2.0.0
+
+# Install specified version of sfctl
+RUN pip install sfctl==${sfctl_version}

--- a/Dockerfiles/Dockerfile.windows
+++ b/Dockerfiles/Dockerfile.windows
@@ -1,0 +1,12 @@
+FROM microsoft/nanoserver
+
+RUN powershell.exe -Command $ErrorActionPreference = 'Stop'; Invoke-WebRequest https://www.python.org/ftp/python/3.6.2/python-3.6.2-embed-amd64.zip -OutFile c:\python3.6.zip ; Expand-Archive c:\python3.6.zip -DestinationPath c:\python3.6; 
+RUN powershell.exe -Command $ErrorActionPreference = 'Stop'; Expand-Archive c:\python3.6\python36.zip -DestinationPath c:\python3.6\python36; 
+RUN powershell.exe -Command Rename-Item -Path c:\python3.6\python36.zip -NewName c:\python3.6\python36.zip.bak
+RUN powershell.exe -Command Rename-Item -Path c:\python3.6\python36 -NewName c:\python3.6\python36.zip
+RUN powershell.exe -Command    $ErrorActionPreference = 'Stop'; Invoke-WebRequest https://bootstrap.pypa.io/get-pip.py -OutFile c:\python3.6\get-pip.py;
+RUN SETX PATH %PATH%;c:\python3.6;c:\python3.6\scripts
+RUN del c:\python3.6\python36._pth
+
+RUN python.exe c:\python3.6\get-pip.py
+RUN pip install sfctl==1.0.1

--- a/README.md
+++ b/README.md
@@ -1,25 +1,189 @@
-# Service Fabric CLI (sfctl)
+# Service Fabric Cross Platform Command-line Interface
 
-Command-line interface for interacting with Azure Service Fabric clusters and
-their related entities.
+Command-line interface(CLI) for interacting with Azure Service Fabric clusters and their related entities.
 
-## Installation
+## Compatibility between sfctl and Service Fabric versions
+sfctl is forward compatible with newer versions of Service Fabric runtime i.e. an older version of sfctl can work with newer versions of Service Fabric runtime but will not support new commands available in later versions. This also means that newer versions of sfctl will not be able to communicate with older versions of Service Fabric.
 
-```bash
-pip install sfctl
+Following table gives the mapping of sfctl versions and Service Fabric runtime versions.
+<table>
+<thead>
+<tr>
+<th>sfctl version</th><th>Service Fabric runtime version</th>
+</tr>
+</thead>
+<tr><td>1.1.0</td><td>5.6.130 or later</td></tr>
+<tr><td>2.0.0</td><td>6.0 and later</td></tr>
+</table>
+	
+## Installing sfctl using pip
+
+#### Perquisite
+[Python 3.6](https://www.python.org/) or later installed on the machine.
+
+pip commands to Install, Upgrade and Uninstall to a central location on the machine require running commands from an admin Command prompt (Windows) or a Terminal window with sudo access (Linux or Mac). On Linux or Mac, prepend sudo to each of these commands below.
+
+#### Install latest version
+```
+pip3 install sfctl
+```
+#### Install a specific version
+Identify the the most appropriate version from table above and specify it in the following command
+```
+pip3 install sfctl==replace-with-required-version
+```
+Following will install version 1.1.0 of sfctl
+```
+pip3 install sfctl==1.1.0
+```
+#### Determine version of sfctl installed on the machine
+```
+pip3 show sfctl
+```
+#### Upgrade to latest version
+```
+pip3 install -U sfctl
+```
+#### Upgrade to specific version
+```
+pip3 install -U sfctl==replace-with-required-version
+```
+#### Uninstall
+```
+pip uninstall -y sfctl
+```
+## Installing multiple versions side-by-side using python virtual environment
+There may be a need to install different versions of sfctl side by side to interact with clusters running different versions of Service Fabric runtime. 
+
+[pipenv](https://docs.pipenv.org/) package can be used to setup a python virtual environment that can be used to install a different version of sfctl separate from the globally installed version.
+
+1. Install pipenv.
+
+    **NOTE:** Only this command requires an admin command prompt or sudo access. Do not use admin command prompt or sudo for rest of the commands below
+    ```
+    pip3 install pipenv
+    ```
+2. Create a directory for installing files for virtual environment (commands below installs sfctl 1.1.0)
+    ```
+    mkdir sfctl-1.1.0
+    ```
+3. Install sfctl in virtual env
+    ```
+    pipenv --three install sfctl-1.1.0
+    ```
+4. Create a shell that uses files in virtual environment
+    ```
+    pipenv --three shell
+    ```
+5. Run 1.1.0 of sfctl
+    ```
+    pip show sfctl
+    sfctl --help
+    ```
+6. Exit virtual environment shell
+    ```
+    exit
+    ```
+7. Run globally installed version of sfctl
+    ```
+    pip show sfctl
+    sfctl --help
+    ```
+
+## Installing multiple versions side-by-side in a Docker container
+sfctl github repo has Dockerfile to generate a container with the required version of sfctl.
+
+1. Install [Docker CE](https://www.docker.com/community-edition) the machine. 
+
+2. Clone [sfctl repo](https://github.com/Azure/service-fabric-cli) using information on the github page - https://github.com/Azure/service-fabric-cli
+
+2. Open a Command Prompt (Windows) or Terminal window (Linux or Mac) and navigate to the Dockerfiles folder under the root of the enlistment
+
+    ```
+    pushd path-to-root-of-enlistment/Dockerfiles
+    ```
+
+3. Build the docker image
+
+    Windows
+    ```
+    REM replace 2.0.0 with required version
+    docker build -t sfctl_2.0.0 -f Dockerfile.windows --build-arg sfctl_version=2.0.0 .
+    ```
+    Linux
+    ```
+    # replace 2.0.0 with required version
+    docker build -t sfctl_2.0.0 -f Dockerfile.linux --build-arg sfctl_version=2.0.0 .
+    ```
+
+4. Start the container in interactive mode. Replace the name of the name of the image with the image for the require version
+    ```
+    docker run -it sfctl_2.0.0
+    ```
+5. Once the container starts at the container command prompt run sfctl
+    ```
+    sfctl -h
+    ...
+    ```
+6. Exit the container
+    ```
+    exit
+    ```
+## Command line options and commands
+ sfctl has extensive help for command line options and commands. --help option gives detailed information
+
+Output from sfctl 2.0.0
+```
+sfctl --help
+
+Group
+    sfctl : Commands for managing Service Fabric clusters and entities. This version is compatible
+    with Service Fabric 6.0 runtime.
+        Commands follow the noun-verb pattern. See subgroups for more information.
+
+Subgroups:
+    application: Create, delete, and manage applications and application types.
+    chaos      : Start, stop and report on the chaos test service.
+    cluster    : Select, manage and operate Service Fabric clusters.
+    compose    : Create, delete and manage Docker Compose applications.
+    is         : Query and send commands to the infrastructure service.
+    node       : Manage the nodes that form a cluster.
+    partition  : Query and manage partitions for any service.
+    replica    : Manage the replicas that belong to service partitions.
+    rpm        : Query and send commands to the repair manager service.
+    sa-cluster : Manage stand-alone Service Fabric clusters.
+    service    : Create, delete and manage service, service types and service packages.
+    store      : Perform basic file level operations on the cluster image store.
+
+
+
+sfctl cluster select --help
+
+Command
+    sfctl cluster select: Connects to a Service Fabric cluster endpoint.
+        If connecting to secure cluster specify a cert (.crt) and key file (.key) or a single file
+        with both (.pem). Do not specify both. Optionally, if connecting to a secure cluster,
+        specify also a path to a CA bundle file or directory of trusted CA certs.
+
+Arguments
+    --endpoint [Required]: Cluster endpoint URL, including port and HTTP or HTTPS prefix.
+    --aad                : Use Azure Active Directory for authentication.
+    --ca                 : Path to CA certs directory to treat as valid or CA bundle file.
+    --cert               : Path to a client certificate file.
+    --key                : Path to client certificate key file.
+    --no-verify          : Disable verification for certificates when using HTTPS, note: this is an
+                           insecure option and should not be used for production environments.
+    --pem                : Path to client certificate, as a .pem file.
+
+Global Arguments
+    --debug              : Increase logging verbosity to show all debug logs.
+    --help -h            : Show this help message and exit.
+    --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
+    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+                           examples.
+    --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 ```
 
-### Launching
-
-```bash
-sfctl <command>
-```
-
-For more information, specify the `-h` flag:
-
-```bash
-sfctl -h
-```
 
 ## Developer Help and Documentation
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ sfctl github repo has Dockerfile to generate a container with the required versi
     docker build -t sfctl_2.0.0 -f Dockerfile.linux --build-arg sfctl_version=2.0.0 .
     ```
 
-4. Start the container in interactive mode. Replace the name of the name of the image with the image for the require version
+4. Start the container in interactive mode. Replace the name of the name of the image with the image for the required version
     ```
     docker run -it sfctl_2.0.0
     ```

--- a/src/sfctl/custom_cluster.py
+++ b/src/sfctl/custom_cluster.py
@@ -7,6 +7,7 @@
 """Cluster level Service Fabric commands"""
 
 from __future__ import print_function
+import sys
 from knack.util import CLIError
 
 import adal
@@ -68,6 +69,8 @@ def select(endpoint, cert=None, key=None, pem=None, ca=None,
 
     select_arg_verify(endpoint, cert, key, pem, ca, aad, no_verify)
 
+    cluster_code_versions = []
+
     if aad:
         new_token, new_cache = get_aad_token(endpoint, no_verify)
         set_aad_cache(new_token, new_cache)
@@ -78,6 +81,12 @@ def select(endpoint, cert=None, key=None, pem=None, ca=None,
 
         # Make sure basic GET request succeeds
         rest_client.send(rest_client.get('/')).raise_for_status()
+
+        # Get cluster version
+        cluster_code_versions = rest_client.send(
+            rest_client.get('/$/GetProvisionedCodeVersions?api-version=3.0')
+        ).json()
+
     else:
         client_cert = None
         if pem:
@@ -93,10 +102,28 @@ def select(endpoint, cert=None, key=None, pem=None, ca=None,
         # Make sure basic GET request succeeds
         rest_client.send(rest_client.get('/')).raise_for_status()
 
+        # Get cluster version
+        cluster_code_versions = rest_client.send(
+            rest_client.get('/$/GetProvisionedCodeVersions?api-version=3.0')
+        ).json()
+
+    #pylint: disable-msg=line-too-long
+    print('Cluster      : ' + endpoint)
+    print('Code Versions: { ' + ", ".join(ver['CodeVersion'] for ver in cluster_code_versions) + " }")
+
+    for version in cluster_code_versions:
+        major_version = version['CodeVersion'][:version['CodeVersion'].index('.')]
+        if major_version is None or int(major_version) < 6:
+            print('\x1b[1;31mStatus       : This version of sfctl does not support Service Fabric version(s) deployed on cluster')
+            print('               Refer to https://github.com/Azure/service-fabric-cli for more details\x1b[0m')
+            sys.exit(1)
+
     set_cluster_endpoint(endpoint)
     set_no_verify(no_verify)
     set_ca_cert(ca)
     set_auth(pem, cert, key, aad)
+    print('\x1b[1;32mStatus       : Successfully connected to cluster\x1b[0m')
+    #pylint: enable-msg=line-too-long
 
 def get_aad_token(endpoint, no_verify):
     #pylint: disable-msg=too-many-locals


### PR DESCRIPTION
@VipulM-MSFT , @vturecek , @suhuruli, @samedder, @mani-ramaswamy  please review the change

Addresses #40 and points to this repo for instructions if there is version mismatch.

Updated install instructions to allow SXS install of different versions of sfctl using pipenv or containers.
