### PR TITLE
Fixing load metric parsing

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -19,7 +19,8 @@ Change Log
 3.0.0
 -----
 
-- Rename compose deployment creation and upgrade progress commands to accept 'deployment-name' as identifier.
+- Rename compose deployment creation and upgrade progress commands to accept 'deployment-name' as identifier (#44)
+- Fix incorrect parsing error when updating service description load metrics (#47) 
 
 2.0.0
 -----

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -53,6 +53,7 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
         arg_context.argument('instance_count', type=int)
         arg_context.argument('target_replica_set_size', type=int)
         arg_context.argument('min_replica_set_size', type=int)
+        arg_context.argument('load_metrics', type=json_encoded)
 
     with ArgumentsContext(self, 'chaos start') as arg_context:
         arg_context.argument('app_type_health_policy_map', type=json_encoded)


### PR DESCRIPTION
Fix load metrics parsing during `service update` by correctly parsing JSON encoded string. Fixes #46.