### PR TITLE
Updated Python SDK version and added property management commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pylint
 vcrpy
 mock
 jsonpickle
+adal

--- a/src/README.rst
+++ b/src/README.rst
@@ -16,6 +16,12 @@ To get started, after installation run the following:
 Change Log
 ==========
 
+3.0.1
+-----
+
+- Update to official 6.0.2 Service Fabric SDK
+- Property command group added
+
 3.0.0
 -----
 

--- a/src/README.rst
+++ b/src/README.rst
@@ -16,7 +16,7 @@ To get started, after installation run the following:
 Change Log
 ==========
 
-3.0.1
+3.1.0
 -----
 
 - Update to official 6.0.2 Service Fabric SDK
@@ -35,7 +35,7 @@ Change Log
 - Update to official 6.0 Service Fabric SDK
 - Report cluster health command added
 - Report health commands now have an immediate argument to tell the Fabric
-  gateway to send the report immeditately
+  gateway to send the report immediately
 - Get cluster configuration and upgrade configuration for stand alone clusters
   commands added
 - Added start and update cluster upgrade commands

--- a/src/setup.py
+++ b/src/setup.py
@@ -46,7 +46,7 @@ setup(
         'knack==0.1.1',
         'msrest>=0.4.4',
         'requests',
-        'azure-servicefabric==6.0',
+        'azure-servicefabric==6.0.2',
         'jsonpickle'
     ],
     extras_require={

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='3.0.0',
+    version='3.0.1',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='3.0.1',
+    version='3.1.0',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',

--- a/src/sfctl/commands.py
+++ b/src/sfctl/commands.py
@@ -203,6 +203,12 @@ class SFCommandLoader(CLICommandsLoader):
                 group.command('command', 'invoke_infrastructure_command')
                 group.command('query', 'invoke_infrastructure_query')
 
+            with super_group.group('property') as group:
+                group.command('put', 'put_property')
+                group.command('list', 'get_property_info_list')
+                group.command('get', 'get_property_info')
+                group.command('delete', 'delete_property')
+
         # Custom commands
 
         with CommandSuperGroup(__name__, self,

--- a/src/sfctl/helps/main.py
+++ b/src/sfctl/helps/main.py
@@ -79,3 +79,8 @@ helps['store'] = """
     short-summary: Perform basic file level operations on the cluster image
         store
 """
+
+helps['property'] = """
+    type: group
+    short-summary: Store and query properties under Service Fabric names
+"""

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -152,3 +152,6 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
         arg_context.argument('unhealthy_app', type=int)
         arg_context.argument('default_svc_type_health_map', type=json_encoded)
         arg_context.argument('svc_type_health_map', type=json_encoded)
+
+    with ArgumentsContext(self, 'property put') as arg_context:
+        arg_context.argument('property_description', type=json_encoded)

--- a/src/sfctl/tests/live_scenario_test.py
+++ b/src/sfctl/tests/live_scenario_test.py
@@ -17,7 +17,7 @@ from sfctl.tests.helpers import (APP_PATH, ENDPOINT, MOCK_CONFIG,
                                  parse_service_type, find_service_manifest)
 
 class ServiceFabricLiveTests(ScenarioTest):
-    """Live scenarion tests for Service Fabric commands"""
+    """Live scenario tests for Service Fabric commands"""
 
     def __init__(self, method_name):
         cli_env = cli()

--- a/src/sfctl/tests/scenario_test.py
+++ b/src/sfctl/tests/scenario_test.py
@@ -12,6 +12,7 @@ from knack.testsdk import (ScenarioTest, JMESPathCheck, NoneCheck)
 from sfctl.entry import cli
 from sfctl.tests.helpers import (ENDPOINT, MOCK_CONFIG)
 
+
 class ServiceFabricScenarioTests(ScenarioTest):
     """Scenario tests for Service Fabric commands"""
 
@@ -34,3 +35,38 @@ class ServiceFabricScenarioTests(ScenarioTest):
             'applicationHealthStates[0].name',
             'fabric:/System'
         )])
+
+    @skipUnless(ENDPOINT, 'Requires live cluster')
+    @patch('sfctl.config.CLIConfig', new=MOCK_CONFIG)
+    def cluster_property_list_test(self):
+        """List System cluster properties"""
+        self.cmd('property list --name {0}'.format("System"),
+                 checks=[JMESPathCheck(
+                     'properties', []
+                 )])
+
+    @skipUnless(ENDPOINT, 'Requires live cluster')
+    @patch('sfctl.config.CLIConfig', new=MOCK_CONFIG)
+    def cluster_property_list_bad_name_test(self): # pylint: disable=invalid-name
+        """List System cluster properties
+         for non existent Service Fabric name"""
+        self.cmd('property list --name {0}'.format("NonExistentName"),
+                 expect_failure=True)
+
+    @skipUnless(ENDPOINT, 'Requires live cluster')
+    @patch('sfctl.config.CLIConfig', new=MOCK_CONFIG)
+    def cluster_property_get_bad_property_test(self): # pylint: disable=invalid-name
+        """Get System cluster property
+         for non existent property"""
+        self.cmd('property get --name {0} --property-name {1}'
+                 .format("System", "NonExistentPropertyName"),
+                 expect_failure=True)
+
+    @skipUnless(ENDPOINT, 'Requires live cluster')
+    @patch('sfctl.config.CLIConfig', new=MOCK_CONFIG)
+    def cluster_property_get_bad_name_test(self): # pylint: disable=invalid-name
+        """Get System cluster property for
+         non existent Service Fabric name"""
+        self.cmd('property get --name {0} --property-name {1}'
+                 .format("NonExistentName", "Test"),
+                 expect_failure=True)


### PR DESCRIPTION
This PR updates the azure-servicefabric Python SDK to v6.0.2 and exposes a subset of the [Property Management APIs](https://docs.microsoft.com/en-us/rest/api/servicefabric/sfclient-index-property-management) via standard commands.
I've only added commands relevant to modifying properties for existing Service Fabric names i.e. 'GettingStartedApplication/WebService' rather than the full name/property API surface. This works for our use case (adding app/service metadata) but appreciate you may want the commands to map to a more generalised API surface. 
Example usage can be seen below:
![sfctl](https://user-images.githubusercontent.com/7241190/32266217-66300b5a-bede-11e7-964e-71a3ca4a179a.PNG)

