### PR TITLE
Updating to 6.1 SF Runtime

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -30,6 +30,10 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
@@ -50,13 +54,85 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call,too-many-arguments,duplicate-code
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=
+enable=c-extension-no-member
 
 
 [REPORTS]
@@ -89,130 +165,11 @@ score=yes
 # Maximum number of nested blocks for function / method body
 max-nested-blocks=5
 
-
-[BASIC]
-
-# Naming hint for argument names
-argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Regular expression matching correct argument names
-# Allow 2 letter arg names for CLI
-argument-rgx=(([a-z][a-z0-9_]{1,30})|(_[a-z0-9_]*))$
-
-# Naming hint for attribute names
-attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Regular expression matching correct attribute names
-attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Regular expression matching correct class attribute names
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
-# Regular expression matching correct class names
-class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-# Naming hint for function names
-function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Regular expression matching correct function names
-function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Good variable names which should always be accepted, separated by a comma
-good-names=f,g,h,i,j,k,l,m,n,ex,Run,_
-
-# Include a hint for the correct naming format with invalid-name
-include-naming-hint=no
-
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
-# Regular expression matching correct inline iteration names
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Naming hint for method names
-method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Regular expression matching correct method names
-method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
-# Regular expression matching correct module names
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=^_
-
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties.
-property-classes=abc.abstractproperty
-
-# Naming hint for variable names
-variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Regular expression matching correct variable names
-variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-
-[FORMAT]
-
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Number of spaces of indent required inside a hanging  or continued line.
-indent-after-paren=4
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
-
-# Maximum number of characters on a single line.
-max-line-length=79
-
-# Maximum number of lines in a module
-max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
-
-# Allow the body of a class to be on the same line as the declaration if body
-# contains single statement.
-single-line-class-stmt=no
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt=no
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
 
 
 [LOGGING]
@@ -222,10 +179,32 @@ single-line-if-stmt=no
 logging-modules=logging
 
 
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME,
+      XXX,
+      TODO
 
 
 [SIMILARITIES]
@@ -241,23 +220,6 @@ ignore-imports=no
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4
-
-
-[SPELLING]
-
-# Spelling dictionary name. Available dictionaries: none. To make it working
-# install python-enchant package.
-spelling-dict=
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
-
-# A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file=
-
-# Tells whether to store unknown words to indicated private dictionary in
-# --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words=no
 
 
 [TYPECHECK]
@@ -319,7 +281,8 @@ allow-global-unused-variables=yes
 
 # List of strings which can identify a callback function by name. A callback
 # name must start or end with one of those strings.
-callbacks=cb_,_cb
+callbacks=cb_,
+          _cb
 
 # A regular expression matching the name of dummy variables (i.e. expectedly
 # not used).
@@ -334,23 +297,151 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,future.builtins
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
 
 
-[CLASSES]
+[FORMAT]
 
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
 
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected=_asdict,_fields,_replace,_source,_make
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg=cls
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
 
-# List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=mcs
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
 
 
 [DESIGN]
@@ -386,6 +477,28 @@ max-statements=50
 min-public-methods=2
 
 
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
 [IMPORTS]
 
 # Allow wildcard imports from modules that define __all__.
@@ -397,7 +510,10 @@ allow-wildcard-with-all=no
 analyse-fallback-blocks=no
 
 # Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,TERMIOS,Bastion,rexec
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
 
 # Create a graph of external dependencies in the given file (report RP0402 must
 # not be disabled)

--- a/pylintrc
+++ b/pylintrc
@@ -126,7 +126,8 @@ disable=print-statement,
         next-method-defined,
         dict-items-not-iterating,
         dict-keys-not-iterating,
-        dict-values-not-iterating
+        dict-values-not-iterating,
+        similarities
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/README.rst
+++ b/src/README.rst
@@ -21,6 +21,7 @@ Change Log
 
 - Update to 6.1 Service Fabric runtime
 - Property command group added
+- Added support for external stores when calling application provision
 
 3.0.0
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -16,6 +16,11 @@ To get started, after installation run the following:
 Change Log
 ==========
 
+3.2.0
+-----
+
+- Update to 6.1 Service Fabric runtime
+
 3.1.0
 -----
 

--- a/src/README.rst
+++ b/src/README.rst
@@ -19,6 +19,7 @@ Change Log
 4.0.0
 -----
 
+- Application provision skeleton added and command removed as part of breaking API change
 - Update to 6.1 Service Fabric runtime
 - Property command group added
 - Added support for external stores when calling application provision

--- a/src/README.rst
+++ b/src/README.rst
@@ -16,12 +16,16 @@ To get started, after installation run the following:
 Change Log
 ==========
 
-3.1.0
+4.0.0
 -----
 
 - Update to 6.1 Service Fabric runtime
 - Property command group added
 - Added support for external stores when calling application provision
+- Provision and unprovision now support no wait return flags
+- Application list related commands now support an optional argument to limit the number of results
+- Deployed application info can now optionally include health states
+- Numerous documentation improvements and corrections
 
 3.0.0
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -16,15 +16,10 @@ To get started, after installation run the following:
 Change Log
 ==========
 
-3.2.0
------
-
-- Update to 6.1 Service Fabric runtime
-
 3.1.0
 -----
 
-- Update to official 6.0.2 Service Fabric SDK
+- Update to 6.1 Service Fabric runtime
 - Property command group added
 
 3.0.0

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='3.2.0',
+    version='3.1.0',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='3.1.0',
+    version='3.2.0',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',
@@ -46,7 +46,7 @@ setup(
         'knack==0.1.1',
         'msrest>=0.4.4',
         'requests',
-        'azure-servicefabric==6.0.2',
+        'azure-servicefabric==6.1.1.9',
         'jsonpickle'
     ],
     extras_require={

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='3.1.0',
+    version='4.0.0',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',

--- a/src/setup.py
+++ b/src/setup.py
@@ -47,7 +47,8 @@ setup(
         'msrest>=0.4.4',
         'requests',
         'azure-servicefabric==6.1.1.9',
-        'jsonpickle'
+        'jsonpickle',
+        'adal'
     ],
     extras_require={
         'test': [

--- a/src/setup.py
+++ b/src/setup.py
@@ -46,7 +46,7 @@ setup(
         'knack==0.1.1',
         'msrest>=0.4.4',
         'requests',
-        'azure-servicefabric==6.1.1.9',
+        'azure-servicefabric==6.1.2.9',
         'jsonpickle',
         'adal'
     ],

--- a/src/sfctl/commands.py
+++ b/src/sfctl/commands.py
@@ -269,7 +269,7 @@ class SFCommandLoader(CLICommandsLoader):
                 group.command('update', 'update')
                 group.command('package-deploy', 'package_upload')
 
-        # TODO: Add when provision API correctly specified in SDK
+        # Only add when provision API correctly specified in SDK
         # with CommandSuperGroup(__name__, self, 'sfctl.custom_app_type#{}',
         #                        client_factory=client_create) as super_group:
         #     with super_group.group('application') as group:

--- a/src/sfctl/commands.py
+++ b/src/sfctl/commands.py
@@ -269,10 +269,11 @@ class SFCommandLoader(CLICommandsLoader):
                 group.command('update', 'update')
                 group.command('package-deploy', 'package_upload')
 
-        with CommandSuperGroup(__name__, self, 'sfctl.custom_app_type#{}',
-                               client_factory=client_create) as super_group:
-            with super_group.group('application') as group:
-                group.command('provision', 'provision_application_type')
+        # TODO: Add when provision API correctly specified in SDK
+        # with CommandSuperGroup(__name__, self, 'sfctl.custom_app_type#{}',
+        #                        client_factory=client_create) as super_group:
+        #     with super_group.group('application') as group:
+        #         group.command('provision', 'provision_application_type')
 
         return OrderedDict(self.command_table)
 

--- a/src/sfctl/commands.py
+++ b/src/sfctl/commands.py
@@ -20,6 +20,7 @@ import sfctl.helps.main # pylint: disable=unused-import
 import sfctl.helps.health # pylint: disable=unused-import
 import sfctl.helps.cluster_upgrade # pylint: disable=unused-import
 import sfctl.helps.compose # pylint: disable=unused-import
+import sfctl.helps.app_type # pylint: disable=unused-import
 
 class SFCommandHelp(CLIHelp):
     """Service Fabric CLI help loader"""
@@ -89,7 +90,6 @@ class SFCommandLoader(CLICommandsLoader):
             with super_group.group('application') as group:
                 group.command('type-list', 'get_application_type_info_list')
                 group.command('type', 'get_application_type_info_list_by_name')
-                group.command('provision', 'provision_application_type')
                 group.command('unprovision', 'unprovision_application_type')
                 group.command('delete', 'delete_application')
                 group.command('list', 'get_application_info_list')
@@ -268,6 +268,11 @@ class SFCommandLoader(CLICommandsLoader):
                 group.command('create', 'create')
                 group.command('update', 'update')
                 group.command('package-deploy', 'package_upload')
+
+        with CommandSuperGroup(__name__, self, 'sfctl.custom_app_type#{}',
+                               client_factory=client_create) as super_group:
+            with super_group.group('application') as group:
+                group.command('provision', 'provision_application_type')
 
         return OrderedDict(self.command_table)
 

--- a/src/sfctl/custom_app.py
+++ b/src/sfctl/custom_app.py
@@ -51,18 +51,18 @@ def upload_to_fileshare(source, dest, show_progress):
         total_files_count += len(files)
 
     for root, _, files in os.walk(source):
-        for f in files:
+        for single_file in files:
             rel_path = root.replace(source, '').lstrip(os.sep)
             dest_path = os.path.join(dest, rel_path)
             if not os.path.isdir(dest_path):
                 os.makedirs(dest_path)
 
             shutil.copyfile(
-                os.path.join(root, f), os.path.join(dest_path, f)
+                os.path.join(root, single_file), os.path.join(dest_path, single_file)
             )
             current_files_count += 1
             print_progress(current_files_count, total_files_count,
-                           os.path.normpath(os.path.join(rel_path, f)),
+                           os.path.normpath(os.path.join(rel_path, single_file)),
                            show_progress)
 
     if show_progress:
@@ -86,12 +86,12 @@ def upload_to_native_imagestore(sesh, endpoint, abspath, basename, #pylint: disa
 
     for root, _, files in os.walk(abspath):
         rel_path = os.path.normpath(os.path.relpath(root, abspath))
-        for f in files:
+        for single_file in files:
             url_path = (
                 os.path.normpath(os.path.join('ImageStore', basename,
-                                              rel_path, f))
+                                              rel_path, single_file))
             ).replace('\\', '/')
-            fp_norm = os.path.normpath(os.path.join(root, f))
+            fp_norm = os.path.normpath(os.path.join(root, single_file))
             with open(fp_norm, 'rb') as file_opened:
                 url_parsed = list(urlparse(endpoint))
                 url_parsed[2] = url_path
@@ -102,7 +102,7 @@ def upload_to_native_imagestore(sesh, endpoint, abspath, basename, #pylint: disa
                 res.raise_for_status()
                 current_files_count += 1
                 print_progress(current_files_count, total_files_count,
-                               os.path.normpath(os.path.join(rel_path, f)),
+                               os.path.normpath(os.path.join(rel_path, single_file)),
                                show_progress)
         url_path = (
             os.path.normpath(os.path.join('ImageStore', basename,

--- a/src/sfctl/custom_app_type.py
+++ b/src/sfctl/custom_app_type.py
@@ -8,15 +8,15 @@
 
 from knack.util import CLIError
 
-def provision_application_type(
-    client,
-    no_wait=False,
-    external=False,
-    application_type_build_path=None,
-    application_package_download_uri=None,
-    application_type_name=None,
-    application_type_version=None,
-    timeout=60
+def provision_application_type( #pylint: disable=invalid-name,missing-docstring,too-many-arguments
+        client,
+        no_wait=False,
+        external=False,
+        application_type_build_path=None,
+        application_package_download_uri=None,
+        application_type_name=None,
+        application_type_version=None,
+        timeout=60
     ):
     from azure.servicefabric.models.provision_application_type_description import (
         ProvisionApplicationTypeDescription
@@ -25,26 +25,24 @@ def provision_application_type(
         ExternalStoreProvisionApplicationTypeDescription
     )
 
-    if(external and not all
-        ([application_package_download_uri,
-        application_type_name,
-        application_type_version])):
+    if external and not all([application_package_download_uri,
+                             application_type_name,
+                             application_type_version]):
         raise CLIError("Must specify download uri, type name and type version")
 
-    if(external and application_type_build_path):
+    if external and application_type_build_path:
         raise CLIError("Cannot specify a build path and external")
 
-    if(not external and not application_type_build_path):
+    if not external and not application_type_build_path:
         raise CLIError("Must specify an application type build path")
 
-    if(not external and any
-        ([application_package_download_uri,
-        application_type_name,
-        application_type_version])):
+    if not external and any([application_package_download_uri,
+                             application_type_name,
+                             application_type_version]):
         raise CLIError("Cannot specify the name, version, nor download uri and external")
 
     provision_desc = None
-    if(external):
+    if external:
         provision_desc = ExternalStoreProvisionApplicationTypeDescription(
             no_wait,
             application_type_name=application_type_name,

--- a/src/sfctl/custom_app_type.py
+++ b/src/sfctl/custom_app_type.py
@@ -1,0 +1,60 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -----------------------------------------------------------------------------
+
+"""Custom application type related commands"""
+
+from knack.util import CLIError
+
+def provision_application_type(
+    client,
+    no_wait=False,
+    external=False,
+    application_type_build_path=None,
+    application_package_download_uri=None,
+    application_type_name=None,
+    application_type_version=None,
+    timeout=60
+    ):
+    from azure.servicefabric.models.provision_application_type_description import (
+        ProvisionApplicationTypeDescription
+    )
+    from azure.servicefabric.models.external_store_provision_application_type_description import (
+        ExternalStoreProvisionApplicationTypeDescription
+    )
+
+    if(external and not all
+        ([application_package_download_uri,
+        application_type_name,
+        application_type_version])):
+        raise CLIError("Must specify download uri, type name and type version")
+
+    if(external and application_type_build_path):
+        raise CLIError("Cannot specify a build path and external")
+
+    if(not external and not application_type_build_path):
+        raise CLIError("Must specify an application type build path")
+
+    if(not external and any
+        ([application_package_download_uri,
+        application_type_name,
+        application_type_version])):
+        raise CLIError("Cannot specify the name, version, nor download uri and external")
+
+    provision_desc = None
+    if(external):
+        provision_desc = ExternalStoreProvisionApplicationTypeDescription(
+            no_wait,
+            application_type_name=application_type_name,
+            application_package_download_uri=application_package_download_uri,
+            application_type_version=application_type_version
+        )
+    else:
+        provision_desc = ProvisionApplicationTypeDescription(
+            no_wait,
+            application_type_build_path=application_type_build_path
+        )
+
+    client.provision_application_type(provision_desc, timeout)

--- a/src/sfctl/custom_cluster.py
+++ b/src/sfctl/custom_cluster.py
@@ -11,7 +11,7 @@ from knack.util import CLIError
 
 import adal
 
-def select_arg_verify(endpoint, cert, key, pem, ca, aad, no_verify):
+def select_arg_verify(endpoint, cert, key, pem, ca, aad, no_verify): #pylint: disable=invalid-name,too-many-arguments
     """Verify arguments for select command"""
 
     if not (endpoint.lower().startswith('http')
@@ -39,7 +39,7 @@ def select_arg_verify(endpoint, cert, key, pem, ca, aad, no_verify):
     if pem and any([cert, key]):
         raise CLIError(usage)
 
-def select(endpoint, cert=None, key=None, pem=None, ca=None,
+def select(endpoint, cert=None, key=None, pem=None, ca=None, #pylint: disable=invalid-name, too-many-arguments
            aad=False, no_verify=False):
     #pylint: disable-msg=too-many-locals
     """

--- a/src/sfctl/custom_cluster_upgrade.py
+++ b/src/sfctl/custom_cluster_upgrade.py
@@ -8,7 +8,7 @@
 
 from knack.util import CLIError
 
-def create_monitoring_policy(failure_action, health_check_wait,
+def create_monitoring_policy(failure_action, health_check_wait, #pylint: disable=too-many-arguments
                              health_check_stable, health_check_retry,
                              upgrade_timeout, upgrade_domain_timeout):
     """Create a monitoring policy description for an upgrade"""
@@ -71,7 +71,7 @@ def parse_app_health_policy(app_health_map):
 
     return ApplicationHealthPolicies(policy_list)
 
-def create_rolling_update_desc(
+def create_rolling_update_desc( #pylint: disable=too-many-arguments
         rolling_upgrade_mode, force_restart, replica_set_check_timeout,
         failure_action, health_check_wait, health_check_stable,
         health_check_retry, upgrade_timeout, upgrade_domain_timeout):
@@ -89,7 +89,7 @@ def create_rolling_update_desc(
         upgrade_domain_timeout_in_milliseconds=upgrade_domain_timeout,
         upgrade_timeout_in_milliseconds=upgrade_timeout)
 
-def upgrade( #pylint: disable=too-many-locals,missing-docstring,invalid-name
+def upgrade( #pylint: disable=too-many-locals,missing-docstring,invalid-name,too-many-arguments
         client, code_version=None, config_version=None,
         rolling_upgrade_mode='UnmonitoredAuto', replica_set_check_timeout=None,
         force_restart=False, failure_action=None, health_check_wait=None,
@@ -125,7 +125,7 @@ def upgrade( #pylint: disable=too-many-locals,missing-docstring,invalid-name
 
     client.start_cluster_upgrade(upgrade_desc, timeout=timeout)
 
-def sa_configuration_upgrade( #pylint: disable=missing-docstring,invalid-name
+def sa_configuration_upgrade( #pylint: disable=missing-docstring,invalid-name,too-many-arguments
         client, cluster_config, health_check_retry='PT0H0M0S',
         health_check_wait='PT0H0M0S', health_check_stable='PT0H0M0S',
         upgrade_domain_timeout='PT0H0M0S', upgrade_timeout='PT0H0M0S',
@@ -147,7 +147,7 @@ def sa_configuration_upgrade( #pylint: disable=missing-docstring,invalid-name
 
     client.start_cluster_configuration_upgrade(upgrade_desc, timeout=timeout)
 
-def update_upgrade( #pylint: disable=too-many-locals,missing-docstring,invalid-name
+def update_upgrade( #pylint: disable=too-many-locals,missing-docstring,invalid-name,too-many-arguments
         client, upgrade_kind='Rolling', rolling_upgrade_mode='UnmonitoredAuto',
         replica_set_check_timeout=None, force_restart=False,
         failure_action=None, health_check_wait=None, health_check_stable=None,

--- a/src/sfctl/custom_compose.py
+++ b/src/sfctl/custom_compose.py
@@ -64,7 +64,7 @@ def create_app_health_policy(
     )
 
 
-def create(client, deployment_name, file_path, user=None, has_pass=False, #pylint: disable=missing-docstring
+def create(client, deployment_name, file_path, user=None, has_pass=False, #pylint: disable=missing-docstring,too-many-arguments
            encrypted_pass=None, timeout=60):
     from azure.servicefabric.models import CreateComposeDeploymentDescription
 
@@ -75,7 +75,7 @@ def create(client, deployment_name, file_path, user=None, has_pass=False, #pylin
     client.create_compose_deployment(desc, timeout=timeout)
 
 
-def upgrade(client, deployment_name, file_path, user=None, has_pass=False, #pylint: disable=missing-docstring,too-many-locals
+def upgrade(client, deployment_name, file_path, user=None, has_pass=False, #pylint: disable=missing-docstring,too-many-locals,too-many-arguments
             encrypted_pass=None, upgrade_kind='Rolling',
             upgrade_mode='UnmonitoredAuto', replica_set_check=None,
             force_restart=False, failure_action=None, health_check_wait=None,

--- a/src/sfctl/custom_health.py
+++ b/src/sfctl/custom_health.py
@@ -55,9 +55,9 @@ def parse_app_health_map(formatted_map):
         return None
 
     health_map = []
-    for m in formatted_map:
-        name = m.get('key', None)
-        percent_unhealthy = m.get('value', None)
+    for item in formatted_map:
+        name = item.get('key', None)
+        percent_unhealthy = item.get('value', None)
         if name is None:
             raise CLIError('Cannot find application type health policy map '
                            'name')
@@ -68,7 +68,7 @@ def parse_app_health_map(formatted_map):
         health_map.append(map_item)
     return health_map
 
-def create_health_information(source_id, health_property, health_state, ttl,
+def create_health_information(source_id, health_property, health_state, ttl, #pylint: disable=too-many-arguments
                               description, sequence_number,
                               remove_when_expired):
     """Validates and creates a health information object"""
@@ -80,7 +80,7 @@ def create_health_information(source_id, health_property, health_state, ttl,
     return HealthInformation(source_id, health_property, health_state, ttl,
                              description, sequence_number, remove_when_expired)
 
-def report_cluster_health(client, source_id, health_property, health_state, #pylint: disable=missing-docstring
+def report_cluster_health(client, source_id, health_property, health_state, #pylint: disable=missing-docstring,too-many-arguments
                           ttl=None, description=None, sequence_number=None,
                           remove_when_expired=False, immediate=False,
                           timeout=60):
@@ -93,7 +93,7 @@ def report_cluster_health(client, source_id, health_property, health_state, #pyl
                                  timeout=timeout)
 
 
-def report_app_health(client, application_id, #pylint: disable=missing-docstring
+def report_app_health(client, application_id, #pylint: disable=missing-docstring,too-many-arguments
                       source_id, health_property, health_state, ttl=None,
                       description=None, sequence_number=None,
                       remove_when_expired=None, immediate=False, timeout=60):
@@ -107,7 +107,7 @@ def report_app_health(client, application_id, #pylint: disable=missing-docstring
                                      immediate=immediate, timeout=timeout)
 
 
-def report_svc_health(client, service_id, source_id, health_property, #pylint: disable=missing-docstring
+def report_svc_health(client, service_id, source_id, health_property, #pylint: disable=missing-docstring,too-many-arguments
                       health_state, ttl=None, description=None,
                       sequence_number=None, remove_when_expired=None,
                       timeout=60, immediate=False):
@@ -120,7 +120,7 @@ def report_svc_health(client, service_id, source_id, health_property, #pylint: d
                                  immediate=immediate)
 
 
-def report_partition_health(client, partition_id, source_id, health_property, #pylint: disable=missing-docstring
+def report_partition_health(client, partition_id, source_id, health_property, #pylint: disable=missing-docstring,too-many-arguments
                             health_state, ttl=None, description=None,
                             sequence_number=None, remove_when_expired=None,
                             immediate=False, timeout=60):
@@ -133,7 +133,7 @@ def report_partition_health(client, partition_id, source_id, health_property, #p
     client.report_partition_health(partition_id, health_info, timeout=timeout,
                                    immediate=immediate)
 
-def report_replica_health(client, partition_id, replica_id, source_id, #pylint: disable=missing-docstring
+def report_replica_health(client, partition_id, replica_id, source_id, #pylint: disable=missing-docstring,too-many-arguments
                           health_state, health_property,
                           service_kind="Stateful", ttl=None, description=None,
                           sequence_number=None, remove_when_expired=None,
@@ -148,7 +148,7 @@ def report_replica_health(client, partition_id, replica_id, source_id, #pylint: 
                                  immediate=immediate)
 
 
-def report_node_health(client, node_name, source_id, health_property, #pylint: disable=missing-docstring
+def report_node_health(client, node_name, source_id, health_property, #pylint: disable=missing-docstring,too-many-arguments
                        health_state, ttl=None, description=None,
                        sequence_number=None, remove_when_expired=None,
                        immediate=False, timeout=60):

--- a/src/sfctl/custom_service.py
+++ b/src/sfctl/custom_service.py
@@ -32,14 +32,14 @@ def parse_load_metrics(formatted_metrics):
     s_load_list = None
     if formatted_metrics:
         s_load_list = []
-        for l in formatted_metrics:
-            l_name = l.get('name', None)
+        for item in formatted_metrics:
+            l_name = item.get('name', None)
             if l_name is None:
                 raise CLIError('Could not find specified load metric name')
-            l_weight = l.get('weight', None)
-            l_primary = l.get('primary_default_load', None)
-            l_secondary = l.get('secondary_default_load', None)
-            l_default = l.get('default_load', None)
+            l_weight = item.get('weight', None)
+            l_primary = item.get('primary_default_load', None)
+            l_secondary = item.get('secondary_default_load', None)
+            l_default = item.get('default_load', None)
             l_desc = ServiceLoadMetricDescription(l_name, l_weight, l_primary,
                                                   l_secondary, l_default)
             s_load_list.append(l_desc)
@@ -112,16 +112,16 @@ def stateful_flags(rep_restart_wait=None, quorum_loss_wait=None,
     """Calculate an integer representation of flag arguments for stateful
     services"""
 
-    f = 0
+    flag_sum = 0
     if rep_restart_wait is not None:
-        f += 1
+        flag_sum += 1
     if quorum_loss_wait is not None:
-        f += 2
+        flag_sum += 2
     if standby_replica_keep is not None:
-        f += 4
-    return f
+        flag_sum += 4
+    return flag_sum
 
-def service_update_flags(
+def service_update_flags( #pylint: disable=too-many-arguments
         target_rep_size=None, instance_count=None, rep_restart_wait=None,
         quorum_loss_wait=None, standby_rep_keep=None, min_rep_size=None,
         placement_constraints=None, placement_policy=None, correlation=None,
@@ -129,31 +129,31 @@ def service_update_flags(
     """Calculate an integer representation of flag arguments for updating
     stateful services"""
 
-    f = 0
+    flag_sum = 0
     if (target_rep_size is not None) or (instance_count is not None):
-        f += 1
+        flag_sum += 1
     if rep_restart_wait is not None:
-        f += 2
+        flag_sum += 2
     if quorum_loss_wait is not None:
-        f += 4
+        flag_sum += 4
     if standby_rep_keep is not None:
-        f += 8
+        flag_sum += 8
     if min_rep_size is not None:
-        f += 16
+        flag_sum += 16
     if placement_constraints is not None:
-        f += 32
+        flag_sum += 32
     if placement_policy is not None:
-        f += 64
+        flag_sum += 64
     if correlation is not None:
-        f += 128
+        flag_sum += 128
     if metrics is not None:
-        f += 256
+        flag_sum += 256
     if move_cost is not None:
-        f += 512
-    return f
+        flag_sum += 512
+    return flag_sum
 
 
-def validate_service_create_params(stateful, stateless, singleton_scheme,
+def validate_service_create_params(stateful, stateless, singleton_scheme, #pylint: disable=too-many-arguments
                                    int_scheme, named_scheme, instance_count,
                                    target_rep_set_size, min_rep_set_size):
     """Validate service creation arguments"""
@@ -176,7 +176,7 @@ def validate_service_create_params(stateful, stateless, singleton_scheme,
             'Cannot specify replica set sizes for statless services'
         )
 
-def parse_partition_policy(named_scheme, named_scheme_list, int_scheme,
+def parse_partition_policy(named_scheme, named_scheme_list, int_scheme, #pylint: disable=too-many-arguments
                            int_scheme_low, int_scheme_high, int_scheme_count,
                            singleton_scheme):
     """Create a partition scheme"""
@@ -345,7 +345,7 @@ def create(  # pylint: disable=too-many-arguments, too-many-locals
 
     client.create_service(app_id, svc_desc, timeout)
 
-def validate_update_service_params(stateless, stateful, target_rep_set_size,
+def validate_update_service_params(stateless, stateful, target_rep_set_size, #pylint: disable=too-many-arguments
                                    min_rep_set_size, rep_restart_wait,
                                    quorum_loss_wait, stand_by_replica_keep,
                                    instance_count):
@@ -375,7 +375,7 @@ def validate_update_service_params(stateless, stateful, target_rep_set_size,
             raise CLIError('Cannot specify an instance count for a stateful '
                            'service')
 
-def update(client, service_id, stateless=False, stateful=False, #pylint: disable=too-many-locals
+def update(client, service_id, stateless=False, stateful=False, #pylint: disable=too-many-locals,too-many-arguments
            constraints=None, correlation=None, correlated_service=None,
            load_metrics=None, placement_policy_list=None,
            move_cost=None, instance_count=None, target_replica_set_size=None,
@@ -489,7 +489,7 @@ def parse_package_sharing_policies(formatted_policies):
     return list_psps
 
 
-def package_upload(client, node_name, service_manifest_name, app_type_name,
+def package_upload(client, node_name, service_manifest_name, app_type_name, #pylint: disable=too-many-arguments
                    app_type_version, share_policy=None, timeout=60):
     """
     Downloads packages associated with specified service manifest to the image

--- a/src/sfctl/helps/app_type.py
+++ b/src/sfctl/helps/app_type.py
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -----------------------------------------------------------------------------
+
+"""Help documentation for Service Fabric application and compose commands."""
+
+from knack.help_files import helps
+
+helps['application provision'] = """
+    type: command
+    short-summary: Provisions or registers a Service Fabric application type with the cluster.
+    long-summary: Provisions a Service Fabric application type with the cluster. This is required
+      before any new applications can be instantiated. The provision operation can be performed
+      either on the application package specified by the relativePathInImageStore, or by using the
+      URI of the external .sfpkg.
+    parameters:
+        - name: --no-wait
+          type: bool
+          short-summary: Indicates the provision operation should return when the request is
+            accepted by the system, and the provision operation continues without any timeout
+            limit.
+        - name: --external
+          type: bool
+          short-summary: Indicates the provision should be performed from an external package
+            source.
+        - name: --application-type-build-path
+          type: string
+          short-summary: The relative path for the application package in the image store specified
+            during the prior upload operation. Only applies if external is not specified.
+        - name: --application-package-download-uri
+          type: string
+          short-summary: The path to the .sfpkg application package from where the application
+            package can be downloaded using HTTP or HTTPS protocols. The application package can be
+            stored in an external store that provides GET operation to download the file. Supported
+            protocols are HTTP and HTTPS, and the path must allow READ access. Only applies if
+            external is specified.
+        - name: --application-type-name
+          type: string
+          short-summary: The application type name represents the name of the application type
+            found in the application manifest. Only applies if external is specified.
+        - name: --application-type-version
+          type: string
+          short-summary: The application type version represents the version of the application
+            type found in the application manifest. Only applies if external is specified.
+"""
+

--- a/src/sfctl/helps/app_type.py
+++ b/src/sfctl/helps/app_type.py
@@ -45,4 +45,3 @@ helps['application provision'] = """
           short-summary: The application type version represents the version of the application
             type found in the application manifest. Only applies if external is specified.
 """
-

--- a/src/sfctl/helps/main.py
+++ b/src/sfctl/helps/main.py
@@ -11,7 +11,7 @@ from knack.help_files import helps
 helps[''] = """
     type: group
     short-summary: Commands for managing Service Fabric clusters
-        and entities. This version is compatible with Service Fabric 6.0
+        and entities. This version is compatible with Service Fabric 6.1
         runtime.
     long-summary: Commands follow the noun-verb pattern. See subgroups for more
         information.

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -30,7 +30,7 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
 
     with ArgumentsContext(self, 'application list') as arg_context:
         arg_context.argument('application_definition_kind_filter', type=int)
-        arg_context.argument('max_results', type=long)
+        arg_context.argument('max_results', type=int)
 
     with ArgumentsContext(self, 'application upgrade') as arg_context:
         arg_context.argument('parameters', type=json_encoded)
@@ -80,7 +80,7 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
         arg_context.argument('services_health_state_filter', type=int)
 
     with ArgumentsContext(self, 'application deployed-list') as arg_context:
-        arg_context.argument('max_results', type=long)
+        arg_context.argument('max_results', type=int)
 
     with ArgumentsContext(self, 'application deployed-health') as arg_context:
         arg_context.argument('events_health_state_filter', type=int)
@@ -159,4 +159,3 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
 
     with ArgumentsContext(self, 'property put') as arg_context:
         arg_context.argument('property_description', type=json_encoded)
-

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -30,6 +30,7 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
 
     with ArgumentsContext(self, 'application list') as arg_context:
         arg_context.argument('application_definition_kind_filter', type=int)
+        arg_context.argument('max_results', type=long)
 
     with ArgumentsContext(self, 'application upgrade') as arg_context:
         arg_context.argument('parameters', type=json_encoded)
@@ -77,6 +78,9 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
         arg_context.argument('deployed_applications_health_state_filter',
                              type=int)
         arg_context.argument('services_health_state_filter', type=int)
+
+    with ArgumentsContext(self, 'application deployed-list') as arg_context:
+        arg_context.argument('max_results', type=long)
 
     with ArgumentsContext(self, 'application deployed-health') as arg_context:
         arg_context.argument('events_health_state_filter', type=int)
@@ -155,3 +159,4 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
 
     with ArgumentsContext(self, 'property put') as arg_context:
         arg_context.argument('property_description', type=json_encoded)
+

--- a/src/sfctl/tests/app_test.py
+++ b/src/sfctl/tests/app_test.py
@@ -8,8 +8,8 @@
 
 import unittest
 import os
-import sfctl.custom_app as sf_c
 from mock import patch, MagicMock
+import sfctl.custom_app as sf_c
 
 class AppTests(unittest.TestCase):
     """App tests"""

--- a/src/sfctl/tests/cluster_test.py
+++ b/src/sfctl/tests/cluster_test.py
@@ -7,8 +7,8 @@
 """Custom cluster command tests"""
 
 import unittest
-import sfctl.custom_cluster as sf_c
 from knack.util import CLIError
+import sfctl.custom_cluster as sf_c
 
 class ClusterTests(unittest.TestCase):
     """Cluster tests"""

--- a/src/sfctl/tests/service_test.py
+++ b/src/sfctl/tests/service_test.py
@@ -7,8 +7,8 @@
 """Custom service command tests"""
 
 import unittest
-import sfctl.custom_service as sf_c
 from knack.util import CLIError
+import sfctl.custom_service as sf_c
 
 #pylint: disable=invalid-name
 


### PR DESCRIPTION
Changes include:
- Updating to 6.1 Service Fabric runtime SDK
- Forcing adal to be a required dependency

Verifed:

- [x] Build and test CI passes
- [x] History and readme updated to reflect changes
- [x] Package version updated according to semantic versioning rules
- [x] Tests modified or added, when applicable
