### PR TITLE
Add support for passing json values to arguments as .txt files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mock
 jsonpickle
 adal
 msrestazure
+contextlib2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ python-coveralls
 nose2
 pylint
 vcrpy
+contextlib2
 mock

--- a/src/README.rst
+++ b/src/README.rst
@@ -26,7 +26,8 @@ Unreleased
 - Fix bug in displaying property help text (#71)
 - Add tests to verify correctness of help text (#71)
 - Add scaling policy parameter to the command for service create and the command for service update (#76)
-- Add container group with commands: invoke-api(invoke raw container REST API), logs(get container logs) (#82)
+- Add new group called container with commands: invoke-api (invoke raw container REST API) and logs (get container logs) (#82)
+- Add support for passing json values to arguments as .txt files
 
 4.0.0
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -27,7 +27,7 @@ Unreleased
 - Add tests to verify correctness of help text (#71)
 - Add scaling policy parameter to the command for service create and the command for service update (#76)
 - Add new group called container with commands: invoke-api (invoke raw container REST API) and logs (get container logs) (#82)
-- Add support for passing json values to arguments as .txt files
+- Add support for passing json values to arguments as .txt files (#84)
 
 4.0.0
 -----

--- a/src/setup.py
+++ b/src/setup.py
@@ -59,7 +59,8 @@ setup(
             'nose2>=0.7.4',
             'pylint',
             'vcrpy',
-            'mock'
+            'mock',
+            'contextlib2'
         ]
     },
     entry_points={

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -8,12 +8,33 @@
 import json
 from knack.arguments import (ArgumentsContext, CLIArgumentType)
 
+
 def json_encoded(arg_str):
-    """Convert from argument JSON string to complex object"""
+    """Convert from argument JSON string to complex object.
+    This function also accepts a file path to a .txt file containing the JSON string.
+    Path can be relative path or absolute path."""
 
-    return json.loads(arg_str)
+    try:
+        with open(arg_str, 'r') as json_file:
+            json_str = json_file.read()
+            return json.loads(json_str)
 
-def custom_arguments(self, _): #pylint: disable=too-many-statements
+    except OSError:
+        pass
+
+    except ValueError as e:
+        print('Decoding JSON value from file {0} failed: \n{1}'.format(arg_str, e))
+        raise
+
+    try:
+        return json.loads(arg_str)
+    except ValueError:
+        print('Hint: You can also pass the json argument in a .txt file. '
+              'To do so, set argument value to the relative or absolute path of the text file.')
+        raise
+
+
+def custom_arguments(self, _):  # pylint: disable=too-many-statements
     """Load specialized arguments for commands"""
 
     # Global argument
@@ -178,4 +199,4 @@ def custom_arguments(self, _): #pylint: disable=too-many-statements
     with ArgumentsContext(self, 'is') as arg_context:
         # expect the parameter command_input in the python method as --command in commandline.
         arg_context.argument('command_input',
-                             CLIArgumentType(options_list=('--command')))
+                             CLIArgumentType(options_list='--command'))

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -5,6 +5,7 @@
 # -----------------------------------------------------------------------------
 
 """Custom parameter handling for commands"""
+from __future__ import print_function
 import json
 from knack.arguments import (ArgumentsContext, CLIArgumentType)
 

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -22,8 +22,8 @@ def json_encoded(arg_str):
     except OSError:
         pass
 
-    except ValueError as e:
-        print('Decoding JSON value from file {0} failed: \n{1}'.format(arg_str, e))
+    except ValueError as ex:
+        print('Decoding JSON value from file {0} failed: \n{1}'.format(arg_str, ex))
         raise
 
     try:

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -18,10 +18,12 @@ def json_encoded(arg_str):
         with open(arg_str, 'r') as json_file:
             json_str = json_file.read()
             return json.loads(json_str)
-
     except OSError:
+        # This is the error that python 3 returns on no file found
         pass
-
+    except IOError:
+        # This is the error that python 2.7 returns on no file found
+        pass
     except ValueError as ex:
         print('Decoding JSON value from file {0} failed: \n{1}'.format(arg_str, ex))
         raise

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -13,24 +13,27 @@ from knack.arguments import (ArgumentsContext, CLIArgumentType)
 def json_encoded(arg_str):
     """Convert from argument JSON string to complex object.
     This function also accepts a file path to a .txt file containing the JSON string.
+    File paths should be prefixed by '@'
     Path can be relative path or absolute path."""
 
-    try:
-        with open(arg_str, 'r') as json_file:
-            json_str = json_file.read()
-            return json.loads(json_str)
-    except IOError:
-        # This is the error that python 2.7 returns on no file found
-        pass
-    except ValueError as ex:
-        print('Decoding JSON value from file {0} failed: \n{1}'.format(arg_str, ex))
-        raise
+    if (arg_str and arg_str[0] == '@'):
+        try:
+            with open(arg_str[1:], 'r') as json_file:
+                json_str = json_file.read()
+                return json.loads(json_str)
+        except IOError:
+            # This is the error that python 2.7 returns on no file found
+            pass
+        except ValueError as ex:
+            print('Decoding JSON value from file {0} failed: \n{1}'.format(arg_str[1:], ex))
+            raise
 
     try:
         return json.loads(arg_str)
     except ValueError:
         print('Hint: You can also pass the json argument in a .txt file. '
-              'To do so, set argument value to the relative or absolute path of the text file.')
+              'To do so, set argument value to the relative or absolute path of the text file '
+              'prefixed by "@".')
         raise
 
 

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -19,9 +19,6 @@ def json_encoded(arg_str):
         with open(arg_str, 'r') as json_file:
             json_str = json_file.read()
             return json.loads(json_str)
-    except OSError:
-        # This is the error that python 3 returns on no file found
-        pass
     except IOError:
         # This is the error that python 2.7 returns on no file found
         pass

--- a/src/sfctl/tests/command_processing_test.py
+++ b/src/sfctl/tests/command_processing_test.py
@@ -74,7 +74,7 @@ class CommandsProcessTests(unittest.TestCase):
                 pass
 
         printed_output = str_io.getvalue()
-        self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_empty_file),
+        self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_empty_file.lstrip('@')),  # pylint: disable=line-too-long
                       printed_output)
         self.assertTrue('Expecting value: line 1 column 1 (char 0)' in printed_output
                         or
@@ -89,7 +89,7 @@ class CommandsProcessTests(unittest.TestCase):
                 pass
 
         printed_output = str_io.getvalue()
-        self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_incorrect_json),
+        self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_incorrect_json.lstrip('@')),  # pylint: disable=line-too-long
                       printed_output)
         self.assertTrue('Expecting property name enclosed in double quotes: line 1 column 2 (char 1)' in printed_output  # pylint: disable=line-too-long
                         or

--- a/src/sfctl/tests/command_processing_test.py
+++ b/src/sfctl/tests/command_processing_test.py
@@ -1,0 +1,124 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -----------------------------------------------------------------------------
+
+"""Tests to ensure that commands are processed correctly"""
+
+import unittest
+from sfctl.params import json_encoded
+from contextlib import redirect_stdout
+from io import StringIO
+from json.decoder import JSONDecodeError
+from os import path
+
+
+class CommandsProcessTests(unittest.TestCase):
+    """Processing commands tests"""
+
+    def test_json_encoded_argument_processing(self):
+        """Make sure that method json_encoded in src/params.py correctly:
+            - Reads the .txt files
+            - If input is not a file, reads and serializes the input as json
+            - Returns correct error messages
+        """
+
+        # --------------------------------------
+        # Pass in json as a string
+        # --------------------------------------
+
+        simple_dictionary = {'k': 23}
+
+        str_io = StringIO()
+
+        with redirect_stdout(str_io):
+            try:
+                json_encoded('')
+            except:  # pylint: disable=broad-except
+                pass
+
+        printed_output = str_io.getvalue()
+        self.assertIn('Hint: You can also pass the json argument in a .txt file', printed_output)
+        self.assertIn('To do so, set argument value to the relative or '
+                      'absolute path of the text file', printed_output)
+
+        str_io = StringIO()
+        with redirect_stdout(str_io):
+            try:
+                json_encoded('{3.14 : "pie"}')
+            except:  # pylint: disable=broad-except
+                pass
+
+        printed_output = str_io.getvalue()
+        self.assertIn('Hint: You can also pass the json argument in a .txt file', printed_output)
+        self.assertIn('To do so, set argument value to the relative or '
+                      'absolute path of the text file', printed_output)
+
+        # Use this here to avoid the printed clutter when running the tests.
+        str_io = StringIO()
+        with redirect_stdout(str_io):
+            with self.assertRaises(JSONDecodeError):
+                json_encoded('')
+            with self.assertRaises(JSONDecodeError):
+                json_encoded('{3.14 : "pie"}')
+
+        self.assertEqual(simple_dictionary, json_encoded('{"k": 23}'))
+
+        # --------------------------------------
+        # Pass in json as a file
+        # --------------------------------------
+
+        # Create object that contains the correct object that should be loaded from reading the file
+        pets_dictionary = dict()
+        pets_dictionary['Coco'] = 'Golden Retriever'
+        pets_dictionary['Lily'] = 'Ragdoll Cat'
+        pets_dictionary['Poofy'] = 'Golden Doodle'
+
+        dictionary = dict()
+        dictionary['name'] = 'John'
+        dictionary['last_name'] = 'Smith'
+        dictionary['pets'] = pets_dictionary
+
+        file_path_correct_json = path.join(path.dirname(__file__), 'correct_json.txt')
+        file_path_incorrect_json = path.join(path.dirname(__file__), 'incorrect_json.txt')
+        file_path_empty_file = path.join(path.dirname(__file__), 'empty_file.txt')
+
+        # Use this here to avoid the printed clutter when running the tests.
+        str_io = StringIO()
+        with redirect_stdout(str_io):
+            with self.assertRaises(JSONDecodeError):
+                json_encoded(file_path_empty_file)
+            with self.assertRaises(JSONDecodeError):
+                json_encoded(file_path_incorrect_json)
+
+        self.assertEqual(dictionary, json_encoded(file_path_correct_json))
+
+        # Test that appropriate error messages are printed out on error
+
+        str_io = StringIO()
+        with redirect_stdout(str_io):
+            try:
+                json_encoded(file_path_empty_file)
+            except:  # pylint: disable=broad-except
+                pass
+
+        printed_output = str_io.getvalue()
+        self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_empty_file),
+                      printed_output)
+        self.assertIn('Expecting value: line 1 column 1 (char 0)', printed_output)
+        self.assertNotIn('Hint: You can also pass the json argument in a .txt file', printed_output)
+
+        str_io = StringIO()
+        with redirect_stdout(str_io):
+            try:
+                json_encoded(file_path_incorrect_json)
+            except:  # pylint: disable=broad-except
+                pass
+
+        printed_output = str_io.getvalue()
+        self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_incorrect_json),
+                      printed_output)
+        self.assertIn('Expecting property name enclosed in double quotes: line 1 column 2 (char 1)',
+                      printed_output)
+        self.assertNotIn('Hint: You can also pass the json argument in a .txt file', printed_output)

--- a/src/sfctl/tests/command_processing_test.py
+++ b/src/sfctl/tests/command_processing_test.py
@@ -6,64 +6,23 @@
 
 """Tests to ensure that commands are processed correctly"""
 
-import unittest
-from sfctl.params import json_encoded
+from os import path
 from contextlib import redirect_stdout
 from io import StringIO
 from json.decoder import JSONDecodeError
-from os import path
+import unittest
+from sfctl.params import json_encoded
 
 
 class CommandsProcessTests(unittest.TestCase):
     """Processing commands tests"""
 
-    def test_json_encoded_argument_processing(self):
+    def test_json_encoded_argument_processing_file_input(self):
         """Make sure that method json_encoded in src/params.py correctly:
             - Reads the .txt files
             - If input is not a file, reads and serializes the input as json
             - Returns correct error messages
         """
-
-        # --------------------------------------
-        # Pass in json as a string
-        # --------------------------------------
-
-        simple_dictionary = {'k': 23}
-
-        str_io = StringIO()
-
-        with redirect_stdout(str_io):
-            try:
-                json_encoded('')
-            except:  # pylint: disable=broad-except
-                pass
-
-        printed_output = str_io.getvalue()
-        self.assertIn('Hint: You can also pass the json argument in a .txt file', printed_output)
-        self.assertIn('To do so, set argument value to the relative or '
-                      'absolute path of the text file', printed_output)
-
-        str_io = StringIO()
-        with redirect_stdout(str_io):
-            try:
-                json_encoded('{3.14 : "pie"}')
-            except:  # pylint: disable=broad-except
-                pass
-
-        printed_output = str_io.getvalue()
-        self.assertIn('Hint: You can also pass the json argument in a .txt file', printed_output)
-        self.assertIn('To do so, set argument value to the relative or '
-                      'absolute path of the text file', printed_output)
-
-        # Use this here to avoid the printed clutter when running the tests.
-        str_io = StringIO()
-        with redirect_stdout(str_io):
-            with self.assertRaises(JSONDecodeError):
-                json_encoded('')
-            with self.assertRaises(JSONDecodeError):
-                json_encoded('{3.14 : "pie"}')
-
-        self.assertEqual(simple_dictionary, json_encoded('{"k": 23}'))
 
         # --------------------------------------
         # Pass in json as a file
@@ -100,7 +59,7 @@ class CommandsProcessTests(unittest.TestCase):
         with redirect_stdout(str_io):
             try:
                 json_encoded(file_path_empty_file)
-            except:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 pass
 
         printed_output = str_io.getvalue()
@@ -113,7 +72,7 @@ class CommandsProcessTests(unittest.TestCase):
         with redirect_stdout(str_io):
             try:
                 json_encoded(file_path_incorrect_json)
-            except:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 pass
 
         printed_output = str_io.getvalue()
@@ -122,3 +81,51 @@ class CommandsProcessTests(unittest.TestCase):
         self.assertIn('Expecting property name enclosed in double quotes: line 1 column 2 (char 1)',
                       printed_output)
         self.assertNotIn('Hint: You can also pass the json argument in a .txt file', printed_output)
+
+    def test_json_encoded_argument_processing_string_input(self):
+        """Make sure that method json_encoded in src/params.py correctly:
+            - Reads the .txt files
+            - If input is not a file, reads and serializes the input as json
+            - Returns correct error messages
+        """
+
+        # --------------------------------------
+        # Pass in json as a string
+        # --------------------------------------
+
+        simple_dictionary = {'k': 23}
+
+        str_io = StringIO()
+
+        with redirect_stdout(str_io):
+            try:
+                json_encoded('')
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        printed_output = str_io.getvalue()
+        self.assertIn('Hint: You can also pass the json argument in a .txt file', printed_output)
+        self.assertIn('To do so, set argument value to the relative or '
+                      'absolute path of the text file', printed_output)
+
+        str_io = StringIO()
+        with redirect_stdout(str_io):
+            try:
+                json_encoded('{3.14 : "pie"}')
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        printed_output = str_io.getvalue()
+        self.assertIn('Hint: You can also pass the json argument in a .txt file', printed_output)
+        self.assertIn('To do so, set argument value to the relative or '
+                      'absolute path of the text file', printed_output)
+
+        # Use this here to avoid the printed clutter when running the tests.
+        str_io = StringIO()
+        with redirect_stdout(str_io):
+            with self.assertRaises(JSONDecodeError):
+                json_encoded('')
+            with self.assertRaises(JSONDecodeError):
+                json_encoded('{3.14 : "pie"}')
+
+        self.assertEqual(simple_dictionary, json_encoded('{"k": 23}'))

--- a/src/sfctl/tests/command_processing_test.py
+++ b/src/sfctl/tests/command_processing_test.py
@@ -7,9 +7,8 @@
 """Tests to ensure that commands are processed correctly"""
 
 from os import path
-from contextlib import redirect_stdout
+from contextlib2 import redirect_stdout
 from io import StringIO
-from json.decoder import JSONDecodeError
 import unittest
 from sfctl.params import json_encoded
 
@@ -17,7 +16,7 @@ from sfctl.params import json_encoded
 class CommandsProcessTests(unittest.TestCase):
     """Processing commands tests"""
 
-    def test_json_encoded_argument_processing_file_input(self):
+    def test_json_encoded_argument_processing_file_input(self):  # pylint: disable=invalid-name
         """Make sure that method json_encoded in src/params.py correctly:
             - Reads the .txt files
             - If input is not a file, reads and serializes the input as json
@@ -44,11 +43,13 @@ class CommandsProcessTests(unittest.TestCase):
         file_path_empty_file = path.join(path.dirname(__file__), 'empty_file.txt')
 
         # Use this here to avoid the printed clutter when running the tests.
+        # Using ValueError instead of json.decoder.JSONDecodeError because that is not
+        # supported in python 2.7
         str_io = StringIO()
         with redirect_stdout(str_io):
-            with self.assertRaises(JSONDecodeError):
+            with self.assertRaises(ValueError):
                 json_encoded(file_path_empty_file)
-            with self.assertRaises(JSONDecodeError):
+            with self.assertRaises(ValueError):
                 json_encoded(file_path_incorrect_json)
 
         self.assertEqual(dictionary, json_encoded(file_path_correct_json))
@@ -82,7 +83,7 @@ class CommandsProcessTests(unittest.TestCase):
                       printed_output)
         self.assertNotIn('Hint: You can also pass the json argument in a .txt file', printed_output)
 
-    def test_json_encoded_argument_processing_string_input(self):
+    def test_json_encoded_argument_processing_string_input(self):  # pylint: disable=invalid-name
         """Make sure that method json_encoded in src/params.py correctly:
             - Reads the .txt files
             - If input is not a file, reads and serializes the input as json
@@ -123,9 +124,9 @@ class CommandsProcessTests(unittest.TestCase):
         # Use this here to avoid the printed clutter when running the tests.
         str_io = StringIO()
         with redirect_stdout(str_io):
-            with self.assertRaises(JSONDecodeError):
+            with self.assertRaises(ValueError):
                 json_encoded('')
-            with self.assertRaises(JSONDecodeError):
+            with self.assertRaises(ValueError):
                 json_encoded('{3.14 : "pie"}')
 
         self.assertEqual(simple_dictionary, json_encoded('{"k": 23}'))

--- a/src/sfctl/tests/command_processing_test.py
+++ b/src/sfctl/tests/command_processing_test.py
@@ -44,7 +44,8 @@ class CommandsProcessTests(unittest.TestCase):
         dictionary['last_name'] = 'Smith'
         dictionary['pets'] = pets_dictionary
 
-        # Test .txt files containing json live in the same folder as this file. Get their full paths.
+        # Test .txt files containing json live in the same folder as this file.
+        # Get their full paths.
         file_path_correct_json = '@' + path.join(path.dirname(__file__), 'correct_json.txt')
         file_path_incorrect_json = '@' + path.join(path.dirname(__file__), 'incorrect_json.txt')
         file_path_empty_file = '@' + path.join(path.dirname(__file__), 'empty_file.txt')

--- a/src/sfctl/tests/command_processing_test.py
+++ b/src/sfctl/tests/command_processing_test.py
@@ -7,9 +7,9 @@
 """Tests to ensure that commands are processed correctly"""
 
 from os import path
-from contextlib2 import redirect_stdout
 from io import StringIO
 import unittest
+from contextlib2 import redirect_stdout
 from sfctl.params import json_encoded
 
 

--- a/src/sfctl/tests/command_processing_test.py
+++ b/src/sfctl/tests/command_processing_test.py
@@ -7,10 +7,16 @@
 """Tests to ensure that commands are processed correctly"""
 
 from os import path
-from io import StringIO
 import unittest
 from contextlib2 import redirect_stdout
 from sfctl.params import json_encoded
+
+try:
+    # Python 2
+    from cStringIO import StringIO
+except ImportError:
+    # Python 3
+    from io import StringIO
 
 
 class CommandsProcessTests(unittest.TestCase):
@@ -66,7 +72,9 @@ class CommandsProcessTests(unittest.TestCase):
         printed_output = str_io.getvalue()
         self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_empty_file),
                       printed_output)
-        self.assertIn('Expecting value: line 1 column 1 (char 0)', printed_output)
+        self.assertTrue('Expecting value: line 1 column 1 (char 0)' in printed_output
+                        or
+                        'No JSON object could be decoded' in printed_output)
         self.assertNotIn('Hint: You can also pass the json argument in a .txt file', printed_output)
 
         str_io = StringIO()
@@ -79,8 +87,9 @@ class CommandsProcessTests(unittest.TestCase):
         printed_output = str_io.getvalue()
         self.assertIn('Decoding JSON value from file {0} failed'.format(file_path_incorrect_json),
                       printed_output)
-        self.assertIn('Expecting property name enclosed in double quotes: line 1 column 2 (char 1)',
-                      printed_output)
+        self.assertTrue('Expecting property name enclosed in double quotes: line 1 column 2 (char 1)' in printed_output  # pylint: disable=line-too-long
+                        or
+                        'Expecting property name: line 1 column 2 (char 1)' in printed_output)
         self.assertNotIn('Hint: You can also pass the json argument in a .txt file', printed_output)
 
     def test_json_encoded_argument_processing_string_input(self):  # pylint: disable=invalid-name

--- a/src/sfctl/tests/correct_json.txt
+++ b/src/sfctl/tests/correct_json.txt
@@ -1,0 +1,9 @@
+{
+    "name":"John",
+    "last_name": "Smith",
+    "pets": {
+        "Coco":"Golden Retriever",
+        "Lily":"Ragdoll Cat",
+        "Poofy":"Golden Doodle"
+    }
+ }

--- a/src/sfctl/tests/help_text_test.py
+++ b/src/sfctl/tests/help_text_test.py
@@ -188,7 +188,6 @@ class HelpTextTests(unittest.TestCase):
 
             if err:
                 err = err.decode('utf-8')
-                print(err, file=stderr)
                 self.assertEqual(b'', err, msg='ERROR: in command: ' + help_command)
 
             if not returned_string:
@@ -198,7 +197,6 @@ class HelpTextTests(unittest.TestCase):
             lines = returned_string.splitlines()
 
             for line in lines:
-                print(line, file=stderr)
 
                 if not line.strip():
                     continue
@@ -242,8 +240,6 @@ class HelpTextTests(unittest.TestCase):
                              msg=('Not all subgroups listed in help text for '
                                   + help_command
                                   + '. This may be a problem due incorrect expected ordering.'))
-
-            print(file=stderr)
 
         except Exception as exception:  # pylint: disable=broad-except
             if not err:

--- a/src/sfctl/tests/help_text_test.py
+++ b/src/sfctl/tests/help_text_test.py
@@ -9,7 +9,6 @@ This only tests for commands/subgroups which are specified in this file."""
 
 from __future__ import print_function
 import unittest
-from sys import stderr
 from subprocess import Popen, PIPE
 
 

--- a/src/sfctl/tests/incorrect_json.txt
+++ b/src/sfctl/tests/incorrect_json.txt
@@ -1,0 +1,1 @@
+{'this_should_be_double_quotes', 70}

--- a/src/sfctl/tests/request_generation_test.py
+++ b/src/sfctl/tests/request_generation_test.py
@@ -12,8 +12,8 @@ This does not require a cluster connection, except the test for provision applic
 from __future__ import print_function
 from os import (remove, environ)
 import json
-import vcr
 import logging
+import vcr
 from mock import patch
 from knack.testsdk import ScenarioTest
 from jsonpickle import decode

--- a/src/sfctl/tests/request_generation_test.py
+++ b/src/sfctl/tests/request_generation_test.py
@@ -202,8 +202,6 @@ class ServiceFabricRequestTests(ScenarioTest):
              '"ApplicationTypeBuildPath": "test_path"}'),
             validate_flat_dictionary)
 
-        return
-
         self.validate_command(  # provision-application-type external-store
             'application provision --external-provision '
             '--application-package-download-uri=test_path --application-type-name=name '

--- a/src/sfctl/tests/request_generation_test.py
+++ b/src/sfctl/tests/request_generation_test.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from os import (remove, environ)
 import json
 import vcr
+import logging
 from mock import patch
 from knack.testsdk import ScenarioTest
 from jsonpickle import decode
@@ -109,11 +110,17 @@ class ServiceFabricRequestTests(ScenarioTest):
 
         # This calls the command and the HTTP request it recorded into
         # generated_file_path
+
+        # Reduce noise in test output for this test only
+        logging.disable(logging.INFO)
         with vcr.use_cassette('paths_generation_test.json', record_mode='all', serializer='json'):
             try:
                 self.cmd(command)
             except Exception as exception:  # pylint: disable=broad-except
                 self.fail('ERROR while running command "{0}". Error: "{1}"'.format(command, str(exception)))
+
+        # re-enable logging
+        logging.disable(logging.NOTSET)
 
         # Read recorded JSON file
         with open(generated_file_path, 'r') as http_recording_file:
@@ -194,6 +201,9 @@ class ServiceFabricRequestTests(ScenarioTest):
              '"Async": false, '
              '"ApplicationTypeBuildPath": "test_path"}'),
             validate_flat_dictionary)
+
+        return
+
         self.validate_command(  # provision-application-type external-store
             'application provision --external-provision '
             '--application-package-download-uri=test_path --application-type-name=name '
@@ -359,7 +369,7 @@ class ServiceFabricRequestTests(ScenarioTest):
             validate_flat_dictionary)
 
         # container commands
-        self.validate_command( # get container logs
+        self.validate_command(  # get container logs
             'sfctl container invoke-api --node-name Node01 --application-id samples/winnodejs '
             '--service-manifest-name NodeServicePackage --code-package-name NodeService.Code '
             '--code-package-instance-id 131668159770315380 --container-api-uri-path "/containers/{id}/logs?stdout=true&stderr=true"',
@@ -368,7 +378,7 @@ class ServiceFabricRequestTests(ScenarioTest):
             ['api-version=6.2', 'ServiceManifestName=NodeServicePackage', 'CodePackageName=NodeService.Code', 'CodePackageInstanceId=131668159770315380', 'timeout=60'],
             ('{"UriPath": "/containers/{id}/logs?stdout=true&stderr=true"}'),
             validate_flat_dictionary)
-        self.validate_command( # get container logs
+        self.validate_command(  # get container logs
             'sfctl container logs --node-name Node01 --application-id samples/winnodejs '
             '--service-manifest-name NodeServicePackage --code-package-name NodeService.Code '
             '--code-package-instance-id 131668159770315380',
@@ -377,10 +387,10 @@ class ServiceFabricRequestTests(ScenarioTest):
             ['api-version=6.2', 'ServiceManifestName=NodeServicePackage', 'CodePackageName=NodeService.Code', 'CodePackageInstanceId=131668159770315380', 'timeout=60'],
             ('{"UriPath": "/containers/{id}/logs?stdout=true&stderr=true"}'),
             validate_flat_dictionary)
-        self.validate_command( # update container
+        self.validate_command(  # update container
             'sfctl container invoke-api --node-name N0020 --application-id nodejs1 --service-manifest-name NodeOnSF '
             '--code-package-name Code --code-package-instance-id 131673596679688285 --container-api-uri-path "/containers/{id}/update"'
-            ' --container-api-http-verb=POST --container-api-body "DummyRequestBody"', # Manual testing with a JSON string for "--container-api-body" works,
+            ' --container-api-http-verb=POST --container-api-body "DummyRequestBody"',  # Manual testing with a JSON string for "--container-api-body" works,
             # Have to pass "DummyRequestBody" here since a real JSON string confuses test validation code.
             'POST',
             '/Nodes/N0020/$/GetApplications/nodejs1/$/GetCodePackages/$/ContainerApi',
@@ -612,12 +622,12 @@ class ServiceFabricRequestTests(ScenarioTest):
             'GET',
             '/Partitions/id/$/GetReplicas/replicaId/$/GetHealth',
             ['api-version=6.0', 'EventsHealthStateFilter=2'])
-        self.validate_command( # info
+        self.validate_command(  # info
             'replica info --partition-id=id --replica-id=replicaId',
             'GET',
             '/Partitions/id/$/GetReplicas/replicaId',
             ['api-version=6.0'])
-        self.validate_command( # list
+        self.validate_command(  # list
             'replica list --continuation-token=ct --partition-id=id',
             'GET',
             '/Partitions/id/$/GetReplicas',
@@ -740,7 +750,7 @@ class ServiceFabricRequestTests(ScenarioTest):
             validate_flat_dictionary)
 
         # Chaos commands:
-        self.validate_command(#get chaos schedule
+        self.validate_command(  # get chaos schedule
             'chaos schedule set ' +
             '--version 0 --start-date-utc 2016-01-01T00:00:00.000Z ' +
             '--expiry-date-utc 2038-01-01T00:00:00.000Z ' +
@@ -765,25 +775,25 @@ class ServiceFabricRequestTests(ScenarioTest):
             '/Tools/Chaos/Schedule',
             ['api-version=6.2'])
 
-        self.validate_command(#get chaos schedule
+        self.validate_command(  # get chaos schedule
             'chaos schedule get',
             'GET',
             '/Tools/Chaos/Schedule',
             ['api-version=6.2'])
 
-        self.validate_command(#stop chaos
+        self.validate_command(  # stop chaos
             'chaos stop',
             'POST',
             '/Tools/Chaos/$/Stop',
             ['api-version=6.0'])
 
-        self.validate_command(#get chaos events
+        self.validate_command(  # get chaos events
             'chaos events',
             'GET',
             '/Tools/Chaos/Events',
             ['api-version=6.2'])
 
-        self.validate_command(#get chaos
+        self.validate_command(  # get chaos
             'chaos get',
             'GET',
             '/Tools/Chaos',


### PR DESCRIPTION
Changes include:

- Give users the option of passing in a .txt file where they have to pass in a json value for an argument.

Verifed:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
